### PR TITLE
VPSからTailscale経由でTraefikに到達するための設定を追加

### DIFF
--- a/ansible/inventories/group_vars/all.yaml
+++ b/ansible/inventories/group_vars/all.yaml
@@ -1,2 +1,5 @@
 # Alloy Configuration
 alloy_disable_reporting: true
+
+# Tailscale Configuration
+tailscale_advertise_routes: "192.168.21.101"

--- a/ansible/inventories/kkg
+++ b/ansible/inventories/kkg
@@ -10,7 +10,6 @@ kkg-wk2 ansible_host=192.168.20.17
 kkg-wk3 ansible_host=192.168.20.18
 conohav2-1 ansible_host=conohav2-1
 xserver-1 ansible_host=xserver-1
-conohav3-1 ansible_host=conohav3-1
 
 [lb]
 kkg-lb1
@@ -69,10 +68,13 @@ kkg-wk3
 [external]
 conohav2-1
 xserver-1
-conohav3-1
 
 [misskey]
 xserver-1
 
-[wireguard]
-conohav3-1
+[tailscale-internal]
+kkg-lb1
+kkg-lb2
+
+[tailscale-external]
+conohav2-1

--- a/ansible/inventories/kkg
+++ b/ansible/inventories/kkg
@@ -10,6 +10,7 @@ kkg-wk2 ansible_host=192.168.20.17
 kkg-wk3 ansible_host=192.168.20.18
 conohav2-1 ansible_host=conohav2-1
 xserver-1 ansible_host=xserver-1
+conohav3-1 ansible_host=conohav3-1
 
 [lb]
 kkg-lb1
@@ -68,6 +69,10 @@ kkg-wk3
 [external]
 conohav2-1
 xserver-1
+conohav3-1
 
 [misskey]
 xserver-1
+
+[wireguard]
+conohav3-1

--- a/ansible/roles/configure-iptables-for-external/handlers/main.yaml
+++ b/ansible/roles/configure-iptables-for-external/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: restart iptables-persistent
+  systemd:
+    name: netfilter-persistent
+    state: restarted
+  become: true

--- a/ansible/roles/configure-iptables-for-external/tasks/main.yaml
+++ b/ansible/roles/configure-iptables-for-external/tasks/main.yaml
@@ -1,0 +1,99 @@
+---
+- block:
+  - name: Enable IPv4 forwarding
+    sysctl:
+      name: net.ipv4.ip_forward
+      value: "1"
+      state: present
+      reload: yes
+  
+  - name: Enable IPv6 forwarding
+    sysctl:
+      name: net.ipv6.conf.all.forwarding
+      value: '1'
+      state: present
+      reload: yes
+
+  - name: Install iptables-persistent package
+    package:
+      name: iptables-persistent
+      state: present
+
+  - name: Set up HTTPS port forwarding (443) to home server
+    iptables:
+      table: nat
+      chain: PREROUTING
+      protocol: tcp
+      destination_port: "443"
+      jump: DNAT
+      to_destination: "{{ tailscale_advertise_routes }}:443"
+      comment: "Forward HTTPS to home server"
+
+  - name: Set up HTTP port forwarding (80) to home server
+    iptables:
+      table: nat
+      chain: PREROUTING
+      protocol: tcp
+      destination_port: "80"
+      jump: DNAT
+      to_destination: "{{ tailscale_advertise_routes }}:80"
+      comment: "Forward HTTP to home server"
+
+  - name: Set up masquerade for home server traffic
+    iptables:
+      table: nat
+      chain: POSTROUTING
+      destination: "{{ tailscale_advertise_routes }}"
+      jump: MASQUERADE
+      comment: "Masquerade traffic to home server"
+
+  - name: Allow forwarding HTTPS traffic to home server
+    iptables:
+      chain: FORWARD
+      protocol: tcp
+      destination_port: "443"
+      destination: "{{ tailscale_advertise_routes }}"
+      jump: ACCEPT
+      comment: "Allow HTTPS forwarding to home server"
+
+  - name: Allow forwarding HTTP traffic to home server
+    iptables:
+      chain: FORWARD
+      protocol: tcp
+      destination_port: "80"
+      destination: "{{ tailscale_advertise_routes }}"
+      jump: ACCEPT
+      comment: "Allow HTTP forwarding to home server"
+
+  - name: Allow established and related connections
+    iptables:
+      chain: FORWARD
+      match:
+        - state
+      ctstate:
+        - ESTABLISHED
+        - RELATED
+      jump: ACCEPT
+      comment: "Allow established and related connections"
+
+  - name: Check if TCPMSS rule already exists
+    shell: iptables -t mangle -C FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+    register: tcpmss_rule_exists
+    failed_when: false
+    changed_when: false
+
+  - name: Clamp MSS to PMTU for forwarded TCP traffic
+    shell: iptables -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+    when: tcpmss_rule_exists.rc != 0
+
+  - name: Create iptables directory if not exists
+    file:
+      path: /etc/iptables
+      state: directory
+      mode: '0755'
+
+  - name: Save iptables rules
+    shell: iptables-save > /etc/iptables/rules.v4
+    notify: restart iptables-persistent
+
+  when: "'tailscale-external' in group_names"

--- a/ansible/roles/configure-tailscale/tasks/main.yaml
+++ b/ansible/roles/configure-tailscale/tasks/main.yaml
@@ -1,0 +1,28 @@
+---
+- name: Retrieve Auth-Key from 1Password
+  ansible.builtin.set_fact:
+    tailscale_auth_key: "{{ lookup('community.general.onepassword', 'tailscale auth-key for kkg', field='authkey', vault='Kubernetes') }}"
+
+- name: Enable IPv4 forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    reload: yes
+
+- name: Enable IPv6 forwarding
+  sysctl:
+    name: net.ipv6.conf.all.forwarding
+    value: '1'
+    state: present
+    reload: yes
+
+- name: Up Tailscale
+  command: tailscale up --authkey {{ tailscale_auth_key }}
+
+- name: Set Tailscale Subnet Routes
+  command: tailscale up --advertise-routes={{ tailscale_advertise_routes }}/32
+  when: inventory_hostname in groups['tailscale-internal']
+
+- name: Set Tailscale Accept Routes
+  command: tailscale set --accept-routes

--- a/ansible/roles/install-alloy/tasks/main.yaml
+++ b/ansible/roles/install-alloy/tasks/main.yaml
@@ -1,4 +1,23 @@
 ---
+- name: Add Grafana repository key
+  shell:
+    cmd: > 
+      curl -fsSL https://apt.grafana.com/gpg.key |
+      gpg --yes --dearmor -o /etc/apt/keyrings/grafana.gpg 
+
+- name: Add Grafana repository
+  shell:
+    cmd: > 
+      echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" |
+      tee /etc/apt/sources.list.d/grafana.list
+
+- name: Install Alloy
+  apt:
+    name:
+      - alloy
+    state: present
+    update_cache: yes
+
 - block:
   - name: Retrieve TLS certificate from 1Password
     ansible.builtin.set_fact:
@@ -32,25 +51,6 @@
       owner: alloy
       group: alloy
   when: inventory_hostname in groups['external']
-
-- name: Add Grafana repository key
-  shell:
-    cmd: > 
-      curl -fsSL https://apt.grafana.com/gpg.key |
-      gpg --yes --dearmor -o /etc/apt/keyrings/grafana.gpg 
-
-- name: Add Grafana repository
-  shell:
-    cmd: > 
-      echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" |
-      tee /etc/apt/sources.list.d/grafana.list
-
-- name: Install Alloy
-  apt:
-    name:
-      - alloy
-    state: present
-    update_cache: yes
 
 - name: Configure Alloy Env
   ansible.builtin.template:

--- a/ansible/roles/install-tailscale/tasks/main.yaml
+++ b/ansible/roles/install-tailscale/tasks/main.yaml
@@ -1,0 +1,35 @@
+---
+- name: Create keyrings directory
+  file:
+    path: /usr/share/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download and add Tailscale GPG key
+  get_url:
+    url: "https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg"
+    dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
+    mode: '0644'
+
+- name: Add Tailscale repository
+  get_url:
+    url: "https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list"
+    dest: /etc/apt/sources.list.d/tailscale.list
+    mode: '0644'
+
+- name: Update apt cache
+  apt:
+    update_cache: true
+
+- name: Install Tailscale packages
+  apt:
+    name:
+      - tailscale
+      - tailscale-archive-keyring
+    state: present
+
+- name: Enable and start tailscaled service
+  systemd:
+    name: tailscaled
+    enabled: true
+    state: started

--- a/ansible/site-tailscale.yaml
+++ b/ansible/site-tailscale.yaml
@@ -1,0 +1,7 @@
+- name: Install Alloy
+  become: true
+  hosts: tailscale-internal:tailscale-external
+  roles:
+    - install-tailscale
+    - configure-tailscale
+    - configure-iptables-for-external

--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -200,6 +200,37 @@ releases:
           - "manifests/traefik/certificate.yaml"
           - "--ignore-not-found=true"
 
+  - name: traefik-external
+    namespace: traefik-external
+    chart: traefik/traefik
+    version: 37.0.0
+    createNamespace: true
+    needs:
+      - cert-manager/cert-manager
+      - external-dns/external-dns
+    values:
+      - values/traefik-external.gotmpl
+    hooks:
+      - events: [postsync]
+        showlogs: true
+        command: "kubectl"
+        args:
+          - "apply"
+          - "-n"
+          - "traefik-external"
+          - "-f"
+          - "manifests/traefik-external/certificate.yaml"
+      - events: [preuninstall]
+        showlogs: true
+        command: "kubectl"
+        args:
+          - "delete"
+          - "-n"
+          - "traefik-external"
+          - "-f"
+          - "manifests/traefik-external/certificate.yaml"
+          - "--ignore-not-found=true"
+
   - name: minio-tenant
     namespace: minio-tenant
     chart: minio/tenant

--- a/helmfile/manifests/traefik-external/certificate.yaml
+++ b/helmfile/manifests/traefik-external/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: traefik-external.str08.net
+  namespace: traefik-external
+spec:
+  secretName: traefik-external.str08.net-dns01
+  dnsNames:
+    - "traefik-external.str08.net"
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer

--- a/helmfile/values/traefik-external.gotmpl
+++ b/helmfile/values/traefik-external.gotmpl
@@ -1,0 +1,27 @@
+logs:
+  access:
+    enabled: true
+
+service:
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "traefik-external.str08.net"
+
+ingressClass:
+  enabled: true
+  isDefaultClass: false
+  name: "traefik-external"
+
+providers:
+  kubernetesCRD:
+    ingressClass: "traefik-external"
+
+  kubernetesIngress:
+    ingressClass:  "traefik-external"
+
+ingressRoute:
+  dashboard:
+    enabled: true
+    matchRule: Host(`traefik-external.str08.net`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
+    entryPoints: ["web", "websecure"]
+    tls: 
+      secretName: "traefik-external.str08.net-dns01"

--- a/manifests/test/nginx/ingress.yaml
+++ b/manifests/test/nginx/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  name: nginx
+  namespace: default
+spec:
+  ingressClassName: traefik-external
+  rules:
+  - host: nginx.pstr.space
+    http:
+      paths:
+      - backend:
+          service:
+            name: nginx
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - nginx.pstr.space
+    secretName: nginx.pstr.space-dns01

--- a/terraform/kkg/cluster-config.yaml
+++ b/terraform/kkg/cluster-config.yaml
@@ -68,6 +68,12 @@ vms:
     type: "load_balancer"
     target_node: "kkg-pve4"
     ip: "192.168.20.12"
+  
+  - name: "test"
+    vmid: 2019
+    type: "load_balancer"
+    target_node: "kkg-pve4"
+    ip: "192.168.20.2"
 
   # Control Plane Nodes
   - name: "kkg-cp1"

--- a/terraform/kkg/cluster-config.yaml
+++ b/terraform/kkg/cluster-config.yaml
@@ -68,12 +68,6 @@ vms:
     type: "load_balancer"
     target_node: "kkg-pve4"
     ip: "192.168.20.12"
-  
-  - name: "test"
-    vmid: 2019
-    type: "load_balancer"
-    target_node: "kkg-pve4"
-    ip: "192.168.20.2"
 
   # Control Plane Nodes
   - name: "kkg-cp1"

--- a/terraform/tailscale/.gitignore
+++ b/terraform/tailscale/.gitignore
@@ -1,0 +1,22 @@
+# Terraform files
+*.tfstate
+*.tfstate.*
+*.tfplan
+*.tfplan.*
+.terraform/
+# .terraform.lock.hcl
+
+# Variable files containing sensitive data
+terraform.tfvars
+*.auto.tfvars
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+.vscode/
+.idea/

--- a/terraform/tailscale/.terraform.lock.hcl
+++ b/terraform/tailscale/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/tailscale/tailscale" {
+  version     = "0.21.1"
+  constraints = "0.21.1"
+  hashes = [
+    "h1:WlL7BJHtxnvC4uR7NyTI95Ej5IDJxKqoSAu6pCwVVRs=",
+    "zh:0ececf1715d6ece1983e773f8b8def68e8d2d455ff1e5d49fffa97a62c629661",
+    "zh:36146ceadff77791297dfdffe3fa39a6a93b8efc5f0cf55e64f8ad9143685bb5",
+    "zh:4e5304e0443fa6f99ac4c280c0d780078c09475c705581199e3dbd1c0b66fc51",
+    "zh:513cfda48dbcec49034984667c65dc8e534efa5a57e8904aa431bd99c65f45eb",
+    "zh:5dd4689231f430226abfb7ebe9762771e107c04fa7b18d76c1042a3ef6ae67dd",
+    "zh:603a9d8b556effa5d62a7d6777cb709b8563f5e5c263f5edfba6bc09ff896dab",
+    "zh:7c4a6749c9bfe368ab60aed8118fd302b5aa7a4b31c57cdc55d742bcff560309",
+    "zh:80d4f3d3172ba7031824e792bbe617b56a251c41c09fdb1a78404e8f1a272fbe",
+    "zh:85ca224be7e90be39886e5ce112b067fc93a01ce1d5de5e97875d64fa60c9271",
+    "zh:9c6593412663acafe569be1f324198dfebdc5799c0b144ff53c3c2c53a4277c4",
+    "zh:b62ca3483297fdc709288f9fe62cad9083daeefbd7ed6f2b36c8dace0511aabb",
+    "zh:b70b9554defc04c541e5a1f7304e540e2dd78c6a8afda92ade21a4a7c5dda236",
+    "zh:d45027054646da28b76922c18ad5581a6415e69dbbeb1af1d71a993f0d88a5a2",
+    "zh:d94dc6cbd25bba14cc2df3151e10029cbf9ad20dfbfbb69dba3fdc1e41d0ac5f",
+  ]
+}

--- a/terraform/tailscale/README.md
+++ b/terraform/tailscale/README.md
@@ -1,0 +1,124 @@
+# Tailscale ACL Terraform Configuration
+
+このディレクトリは、Tailscale の ACL（Access Control List）を Terraform で管理する設定を含みます。
+
+## 概要
+
+- provider: `tailscale/tailscale` (main.tf では `0.21.1` を指定)
+- ACL は `resource "tailscale_acl" "main"` で管理されています。
+
+## 前提条件
+
+1. Tailscale API キー
+   - Tailscale 管理画面の API keys からキーを生成
+   - 環境変数 `TAILSCALE_API_KEY` に設定します。
+
+   ```bash
+   export TAILSCALE_API_KEY="your-api-key-here"
+   ```
+
+   - 補助スクリプト `setup.sh` がリポジトリ内にあり、1Password CLI (`op`) を使ってキーをエクスポートする例を示しています（組織内で 1Password を使っている場合）。
+
+2. Terraform（CLI）がインストールされていること
+
+3. S3 バックエンド（Cloudflare R2）用の認証情報
+   - main.tf では Terraform の S3 backend を Cloudflare R2 エンドポイントへ向ける設定をしています。
+   - バックエンドにアクセスするために以下を設定してください：
+
+   ```bash
+   export AWS_ACCESS_KEY_ID="your-access-key"
+   export AWS_SECRET_ACCESS_KEY="your-secret-key"
+   ```
+
+   - main.tf の backend 設定（抜粋）:
+     - endpoint: https://e334a8146ecc36d6c72387c7e99630ee.r2.cloudflarestorage.com
+     - bucket: `tfstate`
+     - key: `pke/tailscale/terraform.tfstate`
+     - region: `auto` とし、各種検証スキップオプションが有効になっています。
+
+## セットアップと運用手順
+
+### 新規セットアップ
+
+1. 環境変数を設定（上記を参照）
+2. Terraform の初期化
+
+```bash
+terraform init
+```
+
+3. 変更の確認
+
+```bash
+terraform plan
+```
+
+4. 適用
+
+```bash
+terraform apply
+```
+
+### 既存 ACL の取り込み（推奨）
+
+付属の `import_acl.sh` を使うと、前提条件チェック、API 接続確認、`terraform init`、および `terraform import tailscale_acl.main acl` を自動で行います。
+
+```bash
+export TAILSCALE_API_KEY="..."
+export AWS_ACCESS_KEY_ID="..."
+export AWS_SECRET_ACCESS_KEY="..."
+./import_acl.sh
+```
+
+### 手動での import
+
+1. `TAILSCALE_API_KEY` をエクスポート
+2. `terraform init`
+3. ACL を import
+
+```bash
+terraform import tailscale_acl.main acl
+```
+
+4. `terraform plan` で差分を確認し、必要であれば `terraform apply` を実行してください。
+
+## ACL 設定について
+
+ACL の中身は `main.tf` の `acl = jsonencode(...)` で直接定義されています。主な構成要素:
+
+- tagOwners: `tag:k8s-operator`, `tag:k8s`, `tag:kkg-external` など
+- groups: `group:k8s-readers`, `group:prod`, `group:kkg`（例として GitHub ユーザー `Soli0222@github` が割り当てられています）
+- grants: Kubernetes 統合（impersonate 設定）や特定 IP へのアクセス許可
+- acls: デフォルトで全許可（`accept` のルールが1つあります）
+- ssh: SSH の `check` ルール（nonroot や root へのアクセス指定）
+
+実際の JSON は `main.tf` を確認してください。
+
+## 注意事項
+
+- ACL の変更は慎重に行ってください。誤った設定は通信遮断を招く可能性があります。
+- API キーは機密情報です。適切に管理してください。
+- バックエンドの R2（S3）認証情報は安全に保管してください。
+
+## トラブルシューティング
+
+一般的なチェック項目:
+
+- `TAILSCALE_API_KEY`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` が設定されているか
+- `terraform` と `curl` が利用可能か
+- ネットワークから Tailscale API (`https://api.tailscale.com`) にアクセスできるか
+
+付属スクリプト `import_acl.sh` は上記チェックを行い、問題点を出力します。
+
+## リポジトリ内の主なファイル
+
+- `main.tf` - 実際の ACL を保持する Terraform 設定
+- `import_acl.sh` - 既存 ACL を Terraform state に import する補助スクリプト
+- `setup.sh` - 1Password (`op`) から環境変数をエクスポートする補助スクリプト（組織内利用向け）
+- `.terraform.lock.hcl` - プロバイダロックファイル
+- `.gitignore` - 無視設定
+
+## 変更履歴 / メモ
+
+- README を main.tf と実際のスクリプトに合わせて更新しました（Cloudflare R2 backend 設定、必要な環境変数、存在するスクリプトの一覧を反映）。
+

--- a/terraform/tailscale/import_acl.sh
+++ b/terraform/tailscale/import_acl.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# Tailscale ACL Import Script
+# This script imports existing Tailscale ACL configuration into Terraform
+
+set -e
+
+echo "Tailscale ACL Import Script"
+echo "=========================="
+
+# Check if required tools are installed
+echo "1. Checking prerequisites..."
+echo "============================"
+
+if [ -z "$TAILSCALE_API_KEY" ]; then
+    echo "❌ TAILSCALE_API_KEY is not set"
+    echo "   Please set it with: export TAILSCALE_API_KEY='your-api-key'"
+    exit 1
+else
+    echo "✅ TAILSCALE_API_KEY is set"
+fi
+
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "❌ AWS credentials are not set (required for S3 backend)"
+    echo "   Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
+    exit 1
+else
+    echo "✅ AWS credentials are set"
+fi
+
+if ! command -v terraform &> /dev/null; then
+    echo "❌ Terraform is not installed"
+    exit 1
+else
+    TERRAFORM_VERSION=$(terraform version -json | jq -r '.terraform_version')
+    echo "✅ Terraform is installed (version: $TERRAFORM_VERSION)"
+fi
+
+if ! command -v curl &> /dev/null; then
+    echo "❌ curl is not installed"
+    exit 1
+else
+    echo "✅ curl is installed"
+fi
+
+echo ""
+
+# Test Tailscale API connectivity
+echo "2. Testing Tailscale API connectivity..."
+echo "========================================"
+
+echo "Testing API connection..."
+API_RESPONSE=$(curl -s -w "%{http_code}" -H "Authorization: Bearer $TAILSCALE_API_KEY" \
+    "https://api.tailscale.com/api/v2/tailnet/-/acl" -o /tmp/tailscale_acl_test.json)
+
+if [ "$API_RESPONSE" = "200" ]; then
+    echo "✅ API connection successful"
+    echo "   Current ACL retrieved"
+else
+    echo "❌ API connection failed (HTTP $API_RESPONSE)"
+    echo "   Check your API key and network connectivity"
+    rm -f /tmp/tailscale_acl_test.json
+    exit 1
+fi
+
+rm -f /tmp/tailscale_acl_test.json
+echo ""
+
+# Initialize Terraform
+echo "3. Initializing Terraform..."
+echo "============================"
+
+if [ ! -d ".terraform" ]; then
+    echo "Initializing Terraform..."
+    terraform init
+    if [ $? -ne 0 ]; then
+        echo "❌ Terraform initialization failed"
+        exit 1
+    fi
+    echo "✅ Terraform initialized successfully"
+else
+    echo "✅ Terraform already initialized"
+fi
+
+echo ""
+
+# Import ACL
+echo "4. Importing ACL configuration..."
+echo "================================="
+
+echo "Importing Tailscale ACL..."
+terraform import tailscale_acl.main acl
+
+if [ $? -eq 0 ]; then
+    echo "✅ ACL imported successfully"
+else
+    echo "❌ ACL import failed"
+    echo "   This might be normal if the ACL is already imported"
+    echo "   Check with 'terraform plan' to see the current state"
+fi
+
+echo ""
+
+# Validate configuration
+echo "5. Validating configuration..."
+echo "=============================="
+
+echo "Running terraform plan to check configuration..."
+terraform plan
+
+if [ $? -eq 0 ]; then
+    echo "✅ Configuration validation completed"
+    echo ""
+    echo "Import process completed successfully!"
+    echo ""
+    echo "Next steps:"
+    echo "==========="
+    echo "1. Review the output above to ensure no unwanted changes"
+    echo "2. If everything looks good, run: terraform apply"
+    echo "3. If there are differences, adjust the ACL configuration in main.tf"
+else
+    echo "❌ Configuration validation failed"
+    echo "   Please review the errors and adjust main.tf accordingly"
+    exit 1
+fi

--- a/terraform/tailscale/main.tf
+++ b/terraform/tailscale/main.tf
@@ -30,34 +30,16 @@ provider "tailscale" {
 resource "tailscale_acl" "main" {
   acl = jsonencode({
     "tagOwners" = {
-      "tag:k8s-operator" = [],
-      "tag:k8s"          = ["tag:k8s-operator"],
       "tag:kkg-external" = ["group:kkg"],
     }
 
     "groups" = {
-      "group:k8s-readers" = ["Soli0222@github"],
-      "group:prod"        = ["Soli0222@github"],
       "group:kkg"         = ["Soli0222@github"],
     }
 
     "grants" = [
       {
-        "src" = ["group:prod"],
-        "dst" = ["tag:k8s-operator"],
-        "app" = {
-          "tailscale.com/cap/kubernetes" = [{"impersonate" = {"groups" = ["system:masters"]}}],
-        },
-      },
-      {
-        "src" = ["group:k8s-readers"],
-        "dst" = ["tag:k8s-operator"],
-        "app" = {
-          "tailscale.com/cap/kubernetes" = [{"impersonate" = {"groups" = ["tailnet-readers"]}}],
-        },
-      },
-      {
-        "src" = ["group:kkg"],
+        "src" = ["tag:kkg-external"],
         "dst" = ["192.168.21.101/32"],
         "ip"  = ["*:*"],
       },

--- a/terraform/tailscale/main.tf
+++ b/terraform/tailscale/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_providers {
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "0.21.1"
+    }
+  }
+
+  backend "s3" {
+    endpoints = {
+      s3 = "https://e334a8146ecc36d6c72387c7e99630ee.r2.cloudflarestorage.com"
+    }
+    bucket                      = "tfstate"
+    key                         = "pke/tailscale/terraform.tfstate"
+    region                      = "auto"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+  }
+}
+
+provider "tailscale" {
+  # API key is configured via TAILSCALE_API_KEY environment variable
+  # or via the api_key argument
+}
+
+# Tailscale ACL configuration
+resource "tailscale_acl" "main" {
+  acl = jsonencode({
+    "tagOwners" = {
+      "tag:k8s-operator" = [],
+      "tag:k8s"          = ["tag:k8s-operator"],
+      "tag:kkg-external" = ["group:kkg"],
+    }
+
+    "groups" = {
+      "group:k8s-readers" = ["Soli0222@github"],
+      "group:prod"        = ["Soli0222@github"],
+      "group:kkg"         = ["Soli0222@github"],
+    }
+
+    "grants" = [
+      {
+        "src" = ["group:prod"],
+        "dst" = ["tag:k8s-operator"],
+        "app" = {
+          "tailscale.com/cap/kubernetes" = [{"impersonate" = {"groups" = ["system:masters"]}}],
+        },
+      },
+      {
+        "src" = ["group:k8s-readers"],
+        "dst" = ["tag:k8s-operator"],
+        "app" = {
+          "tailscale.com/cap/kubernetes" = [{"impersonate" = {"groups" = ["tailnet-readers"]}}],
+        },
+      },
+      {
+        "src" = ["group:kkg"],
+        "dst" = ["192.168.21.101/32"],
+        "ip"  = ["*:*"],
+      },
+    ]
+
+    "acls" = [
+      {
+        "action" = "accept",
+        "src"    = ["*"],
+        "dst"    = ["*:*"],
+      },
+    ]
+
+    "ssh" = [
+      {
+        "action" = "check",
+        "src"    = ["autogroup:member"],
+        "dst"    = ["autogroup:self"],
+        "users"  = ["autogroup:nonroot", "root"],
+      },
+    ]
+  })
+}

--- a/terraform/tailscale/main.tf
+++ b/terraform/tailscale/main.tf
@@ -31,10 +31,14 @@ resource "tailscale_acl" "main" {
   acl = jsonencode({
     "tagOwners" = {
       "tag:kkg-external" = ["group:kkg"],
+      "tag:service"      = ["group:service"],
+      "tag:operation"    = ["group:operation"],
     }
 
     "groups" = {
       "group:kkg"         = ["Soli0222@github"],
+      "group:service"     = ["Soli0222@github"],
+      "group:operation"   = ["Soli0222@github"],
     }
 
     "grants" = [
@@ -56,9 +60,10 @@ resource "tailscale_acl" "main" {
     "ssh" = [
       {
         "action" = "check",
-        "src"    = ["autogroup:member"],
-        "dst"    = ["autogroup:self"],
-        "users"  = ["autogroup:nonroot", "root"],
+        "src"    = ["tag:operation"],
+        "dst"    = ["tag:service"],
+        "users"  = ["ubuntu"],
+        "action" = "accept",
       },
     ]
   })

--- a/terraform/tailscale/setup.sh
+++ b/terraform/tailscale/setup.sh
@@ -1,0 +1,6 @@
+# This script sets up the environment for the Terraform configuration
+
+export TAILSCALE_API_KEY=$(op item get 'terraform tailscale' --fields label=TAILSCALE_API_KEY --format json | jq -r .value)
+
+export AWS_ACCESS_KEY_ID=$(op item get 'terraform kkg-pve' --fields label=AWS_ACCESS_KEY_ID --format json | jq -r .value)
+export AWS_SECRET_ACCESS_KEY=$(op item get 'terraform kkg-pve' --fields label=AWS_SECRET_ACCESS_KEY --format json | jq -r .value)


### PR DESCRIPTION
This pull request introduces a comprehensive setup for Tailscale integration, external ingress routing, and improved infrastructure management using Ansible, Helm, and Terraform. The main themes are: enabling secure external access via Tailscale and Traefik, configuring automated firewall and routing rules, and establishing infrastructure-as-code management for Tailscale ACLs. Below are the most important changes grouped by theme.

**Tailscale and Network Routing Integration**

* Added Ansible roles and playbooks to install and configure Tailscale on hosts, including retrieval of auth keys, enabling IP forwarding, and advertising subnet routes for internal and external groups (`configure-tailscale`, `install-tailscale`, `group_vars/all.yaml`, `site-tailscale.yaml`). [[1]](diffhunk://#diff-a42fc08056e30c58c9ed22bee8bb4cb261f0c3f4ae8a716e2f6b0ef395696737R1-R28) [[2]](diffhunk://#diff-ec5dc64eb1e528f4321d3c04ea1a5509c8364222961204357c2e56f1dc272a7aR1-R35) [[3]](diffhunk://#diff-f14362204eef5ffbd93c9a69dec798e38a53fe97132bafc10a03290f432aeff0R3-R5) [[4]](diffhunk://#diff-a0facc379b9f8210f58acf6b2f385d518b26ec42846932ae79602b938d61b594R1-R7)
* Implemented automated iptables configuration for hosts in the `tailscale-external` group, enabling NAT, port forwarding for HTTP/HTTPS, traffic masquerading, and connection tracking for forwarded traffic. Includes handler to restart iptables-persistent when rules are updated. [[1]](diffhunk://#diff-ec23e7097451ac02486666a7a0278928055ce7d88fbeb41724fc24d11040fa47R1-R99) [[2]](diffhunk://#diff-c377ba68fbe6d58219ff29c82dfb777c9f2258cf20926a53293311fecfe75776R1-R6)

**Traefik External Ingress Setup**

* Added a new Helm release for `traefik-external` with custom values and certificate management, enabling external ingress routing and dashboard access via DNS and TLS. [[1]](diffhunk://#diff-252cdb8058e8a6e685ecd79ce3e1c1403087f5b096b80c94e2da6ede84f3efd0R203-R233) [[2]](diffhunk://#diff-99095e00185aacedd8a10ce48df8210605287d7b5cf0c142ce416e448ea06bcbR1-R27) [[3]](diffhunk://#diff-4a4f82f4f39352df16cd9750fd06487c6d23d03b3141f4da8e91c2dbf448093eR1-R12)
* Provided a sample ingress manifest for Nginx, demonstrating use of the `traefik-external` ingress class and cert-manager integration for TLS.

**Terraform-based Tailscale ACL Management**

* Introduced a new Terraform module for managing Tailscale ACLs, including provider configuration, S3 backend setup for state storage (using Cloudflare R2), and a resource definition for ACLs with group, tag, grant, and SSH rules. [[1]](diffhunk://#diff-a0ad709a0ba4e3cfd3e2a6a44690a668777623f3e5dc4f6e146baa08ead24dccR1-R70) [[2]](diffhunk://#diff-b1bbeb9107a62b8130997dc969edb9f96aa794fb768a0ba6f989a62b199d2c6cR1-R24)
* Added supporting scripts and documentation for operationalizing Tailscale ACL management: `.gitignore` for sensitive files, `setup.sh` for environment setup via 1Password, `import_acl.sh` for importing existing ACLs, and a detailed `README.md` for usage and troubleshooting. [[1]](diffhunk://#diff-6b477f3d4a28ced1e7bd6b8c6794acca39c28e56965696f024d081473a40d55fR1-R22) [[2]](diffhunk://#diff-d1a46493f1ddfcd71a0990023851e2d7ab41f154cb22cd140f08dbbb4e9dd5dbR1-R6) [[3]](diffhunk://#diff-b8b7bbc948bb52b2f6925e81a3946f9c4729d3b329a0120298e37f43aae038b7R1-R125) [[4]](diffhunk://#diff-db2b6a37520256a8fd9fc8b02b9a0895c81d0e603d646309b42e6d1e9529ee7aR1-R124)

**Alloy Installation Fixes**

* Relocated Alloy installation tasks in Ansible to ensure proper execution order and host targeting, moving repository setup and package installation before TLS certificate retrieval. [[1]](diffhunk://#diff-eb5fc01c834d71bd2e6c338a49ba9f64c82e670e17c54241bd00466397397e23R2-R20) [[2]](diffhunk://#diff-eb5fc01c834d71bd2e6c338a49ba9f64c82e670e17c54241bd00466397397e23L36-L54)

**Inventory and Group Updates**

* Updated Ansible inventory to define new groups for Tailscale internal and external hosts, supporting targeted configuration and routing.