### PR TITLE
ServiceMonitor追加・Alloyコンフィグを調整

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -22,6 +22,8 @@ repositories:
     url: https://soli0222.github.io/helm-charts
   - name: cnpg
     url: https://cloudnative-pg.github.io/charts
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
 
 releases:
   - name: cilium
@@ -439,3 +441,7 @@ releases:
       - traefik-external/traefik-external
     values:
       - values/summaly.gotmpl
+
+  - name: prometheus-operator-crd
+    chart: prometheus-community/prometheus-operator-crds
+    version: 23.0.0

--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -67,6 +67,8 @@ releases:
     namespace: cert-manager
     chart: jetstack/cert-manager
     version: v1.18.2
+    values:
+      - values/cert-manager.gotmpl
     needs:
       - kube-system/cilium
     createNamespace: true

--- a/helmfile/manifests/cert-manager/clusterissuer.yaml
+++ b/helmfile/manifests/cert-manager/clusterissuer.yaml
@@ -23,3 +23,17 @@ spec:
             apiTokenSecretRef:
               name: cloudflare-api-token
               key: apiToken
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-http01
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-http01-account-key
+    solvers:
+    - http01:
+        ingress:
+          ingressClassName: traefik-external

--- a/helmfile/values/1password-connect.gotmpl
+++ b/helmfile/values/1password-connect.gotmpl
@@ -6,3 +6,6 @@ operator:
 connect:
   create: true
   credentials: {{ exec "sh" (list "-c" "op item get 'PKE-kkg 1password-credentials' --fields label=credentials --format json | jq -r .value") | quote }}
+  api:
+   serviceMonitor:
+      enabled: true

--- a/helmfile/values/alloy.gotmpl
+++ b/helmfile/values/alloy.gotmpl
@@ -36,6 +36,16 @@ alloy:
         role = "node"
       }
 
+      // Kubernetes discovery for PodMonitors
+      discovery.kubernetes "podmonitors" {
+        role = "podmonitor"
+      }
+
+      // Kubernetes discovery for ServiceMonitors
+      discovery.kubernetes "servicemonitors" {
+        role = "servicemonitor"
+      }
+
       // Scrape Kubernetes API server metrics
       prometheus.scrape "kubernetes_api" {
         targets = discovery.kubernetes.services.targets
@@ -87,6 +97,24 @@ alloy:
         }
       }
 
+      // Process PodMonitors
+      prometheus.operator.podmonitors "podmonitors" {
+        forward_to = [prometheus.remote_write.default.receiver]
+        
+        clustering {
+          enabled = true
+        }
+      }
+
+      // Process ServiceMonitors
+      prometheus.operator.servicemonitors "servicemonitors" {
+        forward_to = [prometheus.remote_write.default.receiver]
+        
+        clustering {
+          enabled = true
+        }
+      }
+
       // Collect pod logs
       loki.source.podlogs "pod_logs" {
         forward_to = [loki.write.default.receiver]
@@ -105,7 +133,7 @@ alloy:
       }
 
 serviceMonitor:
-  enabled: false
+  enabled: true
 
 ingress:
   enabled: true

--- a/helmfile/values/alloy.gotmpl
+++ b/helmfile/values/alloy.gotmpl
@@ -135,13 +135,85 @@ alloy:
         }
       }
 
-      // Collect pod logs
-      loki.source.podlogs "pod_logs" {
-        forward_to = [loki.write.default.receiver]
+      // Relabel pod discovery targets to add proper labels
+      discovery.relabel "pod_logs" {
+        targets = discovery.kubernetes.pods.targets
+
+        // Label creation - "namespace" field from "__meta_kubernetes_namespace"
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          action = "replace"
+          target_label = "namespace"
+        }
+
+        // Label creation - "pod" field from "__meta_kubernetes_pod_name"
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          action = "replace"
+          target_label = "pod"
+        }
+
+        // Label creation - "container" field from "__meta_kubernetes_pod_container_name"
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          action = "replace"
+          target_label = "container"
+        }
+
+        // Label creation - "app" field from "__meta_kubernetes_pod_label_app_kubernetes_io_name"
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          action = "replace"
+          target_label = "app"
+        }
+
+        // Label creation - "job" field from "__meta_kubernetes_namespace" and "__meta_kubernetes_pod_container_name"
+        rule {
+          source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+          action = "replace"
+          target_label = "job"
+          separator = "/"
+          replacement = "$1"
+        }
+
+        // Label creation - "__path__" field from "__meta_kubernetes_pod_uid" and "__meta_kubernetes_pod_container_name"
+        rule {
+          source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+          action = "replace"
+          target_label = "__path__"
+          separator = "/"
+          replacement = "/var/log/pods/*$1/*.log"
+        }
+
+        // Label creation - "container_runtime" field from "__meta_kubernetes_pod_container_id"
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_id"]
+          action = "replace"
+          target_label = "container_runtime"
+          regex = "^(\\S+):\\/\\/.+$"
+          replacement = "$1"
+        }
+      }
+
+      // Collect pod logs with automatic Kubernetes labels
+      loki.source.kubernetes "pod_logs" {
+        targets    = discovery.relabel.pod_logs.output
+        forward_to = [loki.process.pod_logs.receiver]
         
         clustering {
           enabled = true
         }
+      }
+
+      // Process logs and add cluster label
+      loki.process "pod_logs" {
+        stage.static_labels {
+          values = {
+            cluster = "kkg",
+          }
+        }
+
+        forward_to = [loki.write.default.receiver]
       }
 
       // Scrape Alloy's own metrics
@@ -165,7 +237,7 @@ rbac:
 serviceAccount:
   create: true
 
-# Additional RBAC rules for PrometheusRule access
+# Additional RBAC rules for PrometheusRule access and pod logs
 extraObjects:
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
@@ -177,6 +249,13 @@ extraObjects:
       verbs: ["get", "list", "watch"]
     - apiGroups: ["monitoring.coreos.com"]
       resources: ["prometheusrules"]
+      verbs: ["get", "list", "watch"]
+    # Pod logs collection permissions
+    - apiGroups: [""]
+      resources: ["pods", "pods/log"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["nodes"]
       verbs: ["get", "list", "watch"]
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding

--- a/helmfile/values/alloy.gotmpl
+++ b/helmfile/values/alloy.gotmpl
@@ -19,6 +19,10 @@ alloy:
             "X-Scope-OrgID" = "anonymous",
           }
         }
+        
+        external_labels = {
+          cluster = "kkg",
+        }
       }
 
       // Kubernetes discovery for services
@@ -74,7 +78,7 @@ alloy:
         }
         
         clustering {
-          enabled = true
+          enabled = false  // Disable clustering for node metrics to avoid duplicates
         }
       }
 
@@ -93,7 +97,7 @@ alloy:
         }
         
         clustering {
-          enabled = true
+          enabled = false  // Disable clustering for cAdvisor to avoid duplicates
         }
       }
 
@@ -130,6 +134,10 @@ alloy:
         forward_to = [prometheus.remote_write.default.receiver]
         scrape_interval = "15s"
         metrics_path = "/metrics"
+        
+        clustering {
+          enabled = false  // Don't cluster self-monitoring
+        }
       }
 
 serviceMonitor:

--- a/helmfile/values/alloy.gotmpl
+++ b/helmfile/values/alloy.gotmpl
@@ -25,6 +25,22 @@ alloy:
         }
       }
 
+      // Mimir rules endpoint for PrometheusRule resources
+      mimir.rules.kubernetes "default" {
+        address = "http://mimir-nginx.mimir"
+        tenant_id = "anonymous"
+        
+        // Select all PrometheusRule resources (empty selector)
+        rule_selector {
+          match_labels = {}  // Monitor all PrometheusRule resources
+        }
+        
+        // Select namespaces where PrometheusRule resources are monitored
+        rule_namespace_selector {
+          match_labels = {}  // Monitor all namespaces
+        }
+      }
+
       // Kubernetes discovery for services
       discovery.kubernetes "services" {
         role = "service"
@@ -142,6 +158,38 @@ alloy:
 
 serviceMonitor:
   enabled: true
+
+rbac:
+  create: true
+
+serviceAccount:
+  create: true
+
+# Additional RBAC rules for PrometheusRule access
+extraObjects:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: alloy-prometheusrule-reader
+    rules:
+    - apiGroups: [""]
+      resources: ["namespaces"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["monitoring.coreos.com"]
+      resources: ["prometheusrules"]
+      verbs: ["get", "list", "watch"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: alloy-prometheusrule-reader
+    subjects:
+    - kind: ServiceAccount
+      name: alloy
+      namespace: alloy
+    roleRef:
+      kind: ClusterRole
+      name: alloy-prometheusrule-reader
+      apiGroup: rbac.authorization.k8s.io
 
 ingress:
   enabled: true

--- a/helmfile/values/cert-manager.gotmpl
+++ b/helmfile/values/cert-manager.gotmpl
@@ -1,0 +1,3 @@
+prometheus:
+  servicemonitor:
+    enabled: true

--- a/helmfile/values/cilium.gotmpl
+++ b/helmfile/values/cilium.gotmpl
@@ -25,9 +25,28 @@ enableIPMasqAgent: false
 l2announcements:
   enabled: true
 
+prometheus:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+operator:
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+
+envoy:
+  prometheus:
+    serviceMonitor:
+      enabled: true
+
 hubble:
   relay:
     enabled: true
+    prometheus:
+      serviceMonitor:
+        enabled: true
   ui:
     enabled: true
     ingress:
@@ -41,3 +60,15 @@ hubble:
        - secretName: hubble.str08.net-dns01
          hosts:
            - hubble.str08.net
+  metrics:
+    enableOpenMetrics: true
+    enabled:
+      - dns
+      - drop
+      - tcp
+      - flow
+      - port-distribution
+      - icmp
+      - "httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction"
+    serviceMonitor:
+      enabled: true

--- a/helmfile/values/external-dns.gotmpl
+++ b/helmfile/values/external-dns.gotmpl
@@ -23,3 +23,5 @@ policy: sync
 provider:
   name: cloudflare
 
+serviceMonitor:
+  enabled: true

--- a/helmfile/values/grafana.gotmpl
+++ b/helmfile/values/grafana.gotmpl
@@ -6,6 +6,9 @@ persistence:
     - ReadWriteMany
   size: 10Gi
 
+serviceMonitor:
+  enabled: true
+
 ingress:
   enabled: true
   ingressClassName: traefik

--- a/helmfile/values/loki.gotmpl
+++ b/helmfile/values/loki.gotmpl
@@ -109,3 +109,7 @@ write:
 
 minio:
   enabled: false
+
+monitoring:
+  serviceMonitor:
+    enabled: true

--- a/helmfile/values/mimir.gotmpl
+++ b/helmfile/values/mimir.gotmpl
@@ -31,7 +31,9 @@ mimir:
 
     limits:
       max_global_series_per_user: 500000
-      max_global_metadata_per_user: 100000
+      ingestion_rate: 50000
+      ingestion_burst_size: 1000000
+      out_of_order_time_window: "5m"
 
 ingress:
   enabled: true

--- a/helmfile/values/mimir.gotmpl
+++ b/helmfile/values/mimir.gotmpl
@@ -70,3 +70,7 @@ nginx:
       - hosts:
           - mimir.pstr.space
         secretName: mimir.pstr.space-dns01
+
+metaMonitoring:
+  serviceMonitor:
+    enabled: true

--- a/helmfile/values/traefik-external.gotmpl
+++ b/helmfile/values/traefik-external.gotmpl
@@ -1,9 +1,15 @@
+deployment:
+  replicas: 2
+
 logs:
   access:
     enabled: true
 
 metrics:
   addInternals: true
+  prometheus:
+    serviceMonitor:
+      enabled: true
 
 service:
   annotations:

--- a/helmfile/values/traefik.gotmpl
+++ b/helmfile/values/traefik.gotmpl
@@ -1,9 +1,15 @@
+deployment:
+  replicas: 2
+
 logs:
   access:
     enabled: true
 
 metrics:
   addInternals: true
+  prometheus:
+    serviceMonitor:
+      enabled: true
 
 service:
   annotations:

--- a/manifests/alertmanager/slack.yaml
+++ b/manifests/alertmanager/slack.yaml
@@ -1,0 +1,19 @@
+global: {}
+templates: []
+route:
+  receiver: slack_webhook
+  routes: []
+receivers:
+  - name: slack_webhook
+    slack_configs:
+      - api_url: ${URL_SLACK_WEBHOOK}  # SlackのWebhook URLを環境変数から取得
+        channel: '#alert'  # 送信先チャンネル
+        title: 'Alert: {{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.summary }}{{ end }}'
+        send_resolved: true
+        # オプション: カスタマイズ可能な項目
+        username: 'Alertmanager'
+        icon_emoji: ':warning:'
+        color: '{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}'
+inhibit_rules: []
+


### PR DESCRIPTION
This pull request introduces comprehensive improvements to monitoring, metrics, and logging integrations across the Kubernetes cluster. The changes add ServiceMonitor support for Prometheus across many components, enhance Alloy's observability and RBAC, and update configurations for Alertmanager, Mimir, and other key services. These updates will enable better metrics collection, log aggregation, and alerting, supporting more robust cluster monitoring.

**Monitoring and ServiceMonitor Integration:**

* Added `prometheus-community` Helm chart repository and deployed the `prometheus-operator-crds` release, enabling Prometheus Operator CRDs for advanced monitoring capabilities. [[1]](diffhunk://#diff-252cdb8058e8a6e685ecd79ce3e1c1403087f5b096b80c94e2da6ede84f3efd0R25-R26) [[2]](diffhunk://#diff-252cdb8058e8a6e685ecd79ce3e1c1403087f5b096b80c94e2da6ede84f3efd0R446-R449)
* Enabled ServiceMonitor support for Prometheus in `cilium`, `cert-manager`, `external-dns`, `grafana`, `loki`, `mimir`, `traefik`, and `traefik-external` by updating their respective values files. This allows Prometheus to automatically discover and scrape metrics from these services. [[1]](diffhunk://#diff-665e251346fb802efd868e5398651aad64e9fb5b1a48603a58e33a7e689184fcR28-R49) [[2]](diffhunk://#diff-665e251346fb802efd868e5398651aad64e9fb5b1a48603a58e33a7e689184fcR63-R74) [[3]](diffhunk://#diff-dab1c426b698aa5208e6bd857a8666171fc19e2bc715b96ef65869bc5a5c80cdR1-R3) [[4]](diffhunk://#diff-e79d43c518da30b6e93a2aadd4f28fc082c8f78b797296cc30803e29e59eaa2cR26-R27) [[5]](diffhunk://#diff-358f210982eb7fc85a3858c52206ccd87e3fd465c4710d28f351f90cde075201R9-R11) [[6]](diffhunk://#diff-8a1129147ac91796a0daf0fd8abbc86ca4ea9c88bddf53fa30b1e01c26b15175R112-R115) [[7]](diffhunk://#diff-73e110a3cfebd591f3b35a52ed4e549e3ae85e0f311eca9485971cff414b1871R75-R78) [[8]](diffhunk://#diff-99095e00185aacedd8a10ce48df8210605287d7b5cf0c142ce416e448ea06bcbR1-R12) [[9]](diffhunk://#diff-1f5219cc82b412e43ca5ff10b332088311023956d02eab052aab637bf72095cbR1-R12)

**Alloy Observability Enhancements:**

* Major updates to `alloy.gotmpl`: Added external labels, integrated Mimir rules endpoint for PrometheusRule resources, enabled ServiceMonitor and RBAC, and improved pod log collection with Kubernetes relabeling and log processing. Disabled clustering for certain scrapers to avoid duplicate metrics. [[1]](diffhunk://#diff-b9e462cd66a3420a16915b2f203904d5f9af7dd2aaad837d7f80d30fb5903aa9R22-R41) [[2]](diffhunk://#diff-b9e462cd66a3420a16915b2f203904d5f9af7dd2aaad837d7f80d30fb5903aa9R59-R68) [[3]](diffhunk://#diff-b9e462cd66a3420a16915b2f203904d5f9af7dd2aaad837d7f80d30fb5903aa9L67-R97) [[4]](diffhunk://#diff-b9e462cd66a3420a16915b2f203904d5f9af7dd2aaad837d7f80d30fb5903aa9R115-R271)

**RBAC and Security Improvements:**

* Added RBAC rules and bindings for Alloy, granting permissions to access PrometheusRule resources and pod logs, supporting secure and compliant metrics and log collection.

**Alerting and Certificate Management:**

* Introduced an Alertmanager Slack integration manifest for sending alerts to Slack channels, improving incident response workflows.
* Added a new `ClusterIssuer` for cert-manager to support HTTP-01 challenges with Traefik ingress, facilitating automated certificate management. [[1]](diffhunk://#diff-e7a4e09b8a128ee25edd1aed41edd7a89c37afc8518ebe7bfb7146b84eb8df26R26-R39) [[2]](diffhunk://#diff-252cdb8058e8a6e685ecd79ce3e1c1403087f5b096b80c94e2da6ede84f3efd0R70-R71)

**Miscellaneous Improvements:**

* Updated Mimir configuration to optimize ingestion rates and out-of-order data handling for more efficient metrics storage.
* Enabled ServiceMonitor for 1Password Connect API to allow Prometheus monitoring.