### PR TITLE
fix(argocd): targetRevisionを10.1.3に戻す

### DIFF
--- a/argocd/grafana/application.yaml
+++ b/argocd/grafana/application.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - chart: grafana
       repoURL: https://grafana.github.io/helm-charts
-      targetRevision: 10.1.4
+      targetRevision: 10.1.3
       helm:
         valueFiles:
           - $values/argocd/grafana/values.yaml


### PR DESCRIPTION
- argocd/grafana/application.yamlのtargetRevisionを10.1.4から10.1.3に変更