### PR TITLE
feat(argocd): tempoアプリケーションと関連リソースを追加

### DIFF
--- a/argocd/tempo/application.yaml
+++ b/argocd/tempo/application.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tempo
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  project: default
+  sources:
+    - chart: tempo-distributed
+      repoURL: https://grafana.github.io/helm-charts
+      targetRevision: 1.53.2
+      helm:
+        valueFiles:
+          - $values/argocd/tempo/values.yaml
+    - repoURL: https://github.com/Soli0222/pke.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/Soli0222/pke.git
+      targetRevision: HEAD
+      path: argocd/tempo/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tempo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/tempo/manifests/ingress-external.yaml
+++ b/argocd/tempo/manifests/ingress-external.yaml
@@ -1,0 +1,81 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tempo-external
+  labels:
+    helm.sh/chart: tempo-distributed-1.53.2
+    app.kubernetes.io/name: tempo
+    app.kubernetes.io/instance: tempo
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    external-dns.alpha.kubernetes.io/target: conohav2-1.pstr.space
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  ingressClassName: traefik-external
+  tls:
+    - hosts:
+        - "tempo.pstr.space"
+      secretName: tempo.pstr.space-dns01
+  rules:
+    - host: "tempo.pstr.space"
+      http:
+        paths:
+          - path: /compactor/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-compactor
+                port:
+                  number: 3200
+          - path: /v1/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-distributor
+                port:
+                  number: 4318
+          - path: /distributor/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-distributor
+                port:
+                  number: 3200
+          - path: /ingester/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-distributor
+                port:
+                  number: 3200
+          - path: /metrics-generator/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-distributor
+                port:
+                  number: 3200
+          - path: /flush
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-ingester
+                port:
+                  number: 3200
+          - path: /shutdown
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-ingester
+                port:
+                  number: 3200
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-query-frontend
+                port:
+                  number: 3200

--- a/argocd/tempo/manifests/onepassworditem.yaml
+++ b/argocd/tempo/manifests/onepassworditem.yaml
@@ -1,0 +1,6 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: minio-secrets
+spec:
+  itemPath: vaults/Kubernetes/items/minio-secrets

--- a/argocd/tempo/values.yaml
+++ b/argocd/tempo/values.yaml
@@ -1,0 +1,41 @@
+global:
+  extraArgs:
+    - "-config.expand-env=true"
+  extraEnvFrom:
+    - secretRef:
+        name: minio-secrets
+
+minio:
+  enabled: false
+
+storage:
+  trace:
+    backend: s3
+    s3:
+      access_key: "${S3_ACCESS_KEY_ID}"
+      secret_key: "${S3_SECRET_ACCESS_KEY}"
+      bucket: "tempo-traces"
+      endpoint: "minio.str08.net"
+      region: "minio-kkg-1"
+      forcepathstyle: true
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  ingressClassName: traefik
+  hosts:
+    - tempo.str08.net
+  tls:
+    - hosts:
+        - tempo.str08.net
+      secretName: tempo.str08.net-dns01
+
+queryFrontend:
+  extraArgs:
+    - "-config.expand-env=true"
+
+metaMonitoring:
+  serviceMonitor:
+    enabled: true


### PR DESCRIPTION
- argocd/tempo/application.yaml: tempoアプリケーションの定義を追加
- argocd/tempo/manifests/ingress-external.yaml: tempoの外部Ingressリソースを追加
- argocd/tempo/manifests/onepassworditem.yaml: minioシークレットのOnePasswordItemを追加
- argocd/tempo/values.yaml: tempoの設定値を追加