### PR TITLE
fix(n8n): valkeyのイメージ設定をbitnamiからvalkeyに向け変え

### DIFF
--- a/argocd/n8n/values.yaml
+++ b/argocd/n8n/values.yaml
@@ -90,7 +90,7 @@ valkey:
   image:
     registry: docker.io
     repository: valkey/valkey
-    tag: 9.0.0-alpine
+    tag: 9.0.0-alpine3.22
   architecture: standalone
   auth:
     enabled: false


### PR DESCRIPTION
- valkeyのイメージ情報を追加し、docker.ioのvalkey/valkeyリポジトリを指定した。