### PR TITLE
chore(spotify-nowplaying: バージョンを2.0.0に更新

### DIFF
--- a/argocd/spotify-nowplaying/application.yaml
+++ b/argocd/spotify-nowplaying/application.yaml
@@ -10,13 +10,16 @@ spec:
   sources:
     - chart: spotify-nowplaying
       repoURL: https://soli0222.github.io/helm-charts
-      targetRevision: 1.0.1
+      targetRevision: 2.0.0
       helm:
         valueFiles:
           - $values/argocd/spotify-nowplaying/values.yaml
     - repoURL: https://github.com/Soli0222/pke.git
       targetRevision: HEAD
       ref: values
+    - repoURL: https://github.com/Soli0222/pke.git
+      targetRevision: HEAD
+      path: argocd/spotify-nowplaying/manifests
   destination:
     server: https://kubernetes.default.svc
     namespace: spotify-nowplaying

--- a/argocd/spotify-nowplaying/manifests/onepassworditem.yaml
+++ b/argocd/spotify-nowplaying/manifests/onepassworditem.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: spotify-nowplaying-secret
+  namespace: spotify-nowplaying
+spec:
+  itemPath: vaults/Kubernetes/items/spotify-nowplaying-secret

--- a/argocd/spotify-nowplaying/values.yaml
+++ b/argocd/spotify-nowplaying/values.yaml
@@ -3,7 +3,7 @@ ingress:
   className: traefik-external
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    external-dns.alpha.kubernetes.io/target: 157.7.66.200
+    external-dns.alpha.kubernetes.io/target: conohav2-1.pstr.space
   hosts:
     - host: spn.soli0222.com
       paths:
@@ -14,16 +14,17 @@ ingress:
         - spn.soli0222.com
       secretName: spn.soli0222.com-dns01
 
-onePassword:
-  enabled: true
-  itemPath: "vaults/Kubernetes/items/spotify-nowplaying-secret"
-
 env:
-  - name: PORT
-    value: "8080"
   - name: SERVER_URI
     value: "mi.soli0222.com"
   - name: SPOTIFY_REDIRECT_URI_NOTE
     value: "https://spn.soli0222.com/note/callback"
   - name: SPOTIFY_REDIRECT_URI_TWEET
     value: "https://spn.soli0222.com/tweet/callback"
+
+monitoring:
+  serviceMonitor:
+    enabled: true
+
+  prometheusRule:
+    enabled: true


### PR DESCRIPTION
- application.yamlのtargetRevisionを1.0.1から2.0.0に変更
- onepassworditem.yamlを新規作成し、spotify-nowplaying-secretの設定を追加
- values.yamlのexternal-dnsのターゲットを157.7.66.200からconohav2-1.pstr.spaceに変更