### PR TITLE
chore(application): upgrade helm chart spotify-nowplaying v3.0.0

### DIFF
--- a/argocd/spotify-nowplaying/application.yaml
+++ b/argocd/spotify-nowplaying/application.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - chart: spotify-nowplaying
       repoURL: https://soli0222.github.io/helm-charts
-      targetRevision: 2.0.1
+      targetRevision: 3.0.0
       helm:
         valueFiles:
           - $values/argocd/spotify-nowplaying/values.yaml

--- a/argocd/spotify-nowplaying/manifests/cluster.yaml
+++ b/argocd/spotify-nowplaying/manifests/cluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: spn-cluster
+spec:
+  instances: 3
+  storage:
+    size: 5Gi
+  bootstrap:
+    initdb:
+      database: spn
+      owner: spn

--- a/argocd/spotify-nowplaying/values.yaml
+++ b/argocd/spotify-nowplaying/values.yaml
@@ -14,13 +14,14 @@ ingress:
         - spn.soli0222.com
       secretName: spn.soli0222.com-dns01
 
-env:
-  - name: SERVER_URI
-    value: "mi.soli0222.com"
-  - name: SPOTIFY_REDIRECT_URI_NOTE
-    value: "https://spn.soli0222.com/note/callback"
-  - name: SPOTIFY_REDIRECT_URI_TWEET
-    value: "https://spn.soli0222.com/tweet/callback"
+
+config:
+  baseUrl: "https://spn.soli0222.com"
+  serverUri: "mi.soli0222.com"
+  twitterEnabled: "true"
+  twitterRequireMisskey: "true"
+  twitterAllowedHosts: "mi.soli0222.com"
+  existingSecret: "spotify-nowplaying-secret"
 
 monitoring:
   serviceMonitor:
@@ -28,3 +29,16 @@ monitoring:
 
   prometheusRule:
     enabled: true
+
+postgres:
+  enabled: false
+
+externalPostgres:
+  host: "spn-cluster-rw"
+  port: 5432
+  username: "spn"
+  database: "spn"
+
+  auth:
+    existingSecret: "spn-cluster-app"
+    secretKey: "password"


### PR DESCRIPTION
- application.yamlのspotify-nowplayingチャートのtargetRevisionを2.0.1から3.0.0に更新
- 新しいcluster.yamlファイルを追加し、PostgreSQLクラスタの設定を定義
- values.yamlにPostgreSQLの設定を追加し、環境変数の定義を整理