### PR TITLE
fix(kube-state-metrics): honorLabelsをvalues.yamlに追加

### DIFF
--- a/argocd/kube-state-metrics/values.yaml
+++ b/argocd/kube-state-metrics/values.yaml
@@ -1,3 +1,4 @@
 prometheus:
   monitor:
     enabled: true
+    honorLabels: true


### PR DESCRIPTION
- values.yamlにhonorLabelsを追加して、Prometheusのモニタリング設定を強化した。