### PR TITLE
feat(tempo): Tempoアプリケーションと関連リソースの追加

### DIFF
--- a/argocd/minio-tenant/values.yaml
+++ b/argocd/minio-tenant/values.yaml
@@ -30,6 +30,8 @@ tenant:
       region: minio-kkg-1
     - name: mimir-ruler
       region: minio-kkg-1
+    - name: tempo-traces
+      region: minio-kkg-1
 
   metrics:
     enabled: true

--- a/argocd/tempo/application.yaml
+++ b/argocd/tempo/application.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tempo
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - chart: tempo-distributed
+      repoURL: https://grafana.github.io/helm-charts
+      targetRevision: 1.61.3
+      helm:
+        valueFiles:
+          - $values/argocd/tempo/values.yaml
+    - repoURL: https://github.com/Soli0222/pke.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/Soli0222/pke.git
+      targetRevision: HEAD
+      path: argocd/tempo/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tempo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argocd/tempo/manifests/ingress-external.yaml
+++ b/argocd/tempo/manifests/ingress-external.yaml
@@ -1,0 +1,82 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tempo-external
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    external-dns.alpha.kubernetes.io/target: conohav2-1.pstr.space
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    traefik.ingress.kubernetes.io/router.tls.options: tempo-mtls@kubernetescrd
+spec:
+  ingressClassName: traefik-external
+  tls:
+    - hosts:
+        - "tempo.pstr.space"
+      secretName: tempo.pstr.space-dns01
+  rules:
+    - host: "tempo.pstr.space"
+      http:
+        paths:
+          - path: /v1/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-distributor
+                port:
+                  number: 4318
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-query-frontend
+                port:
+                  number: 3200
+          - path: /tempo
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-query-frontend
+                port:
+                  number: 3200
+          - path: /compactor/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-compactor
+                port:
+                  number: 3200
+          - path: /distributor/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-distributor
+                port:
+                  number: 3200
+          - path: /ingester/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-distributor
+                port:
+                  number: 3200
+          - path: /metrics-generator/ring
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-distributor
+                port:
+                  number: 3200
+          - path: /flush
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-ingester
+                port:
+                  number: 3200
+          - path: /shutdown
+            pathType: Prefix
+            backend:
+              service:
+                name: tempo-ingester
+                port:
+                  number: 3200

--- a/argocd/tempo/manifests/mtls-ca.yaml
+++ b/argocd/tempo/manifests/mtls-ca.yaml
@@ -1,0 +1,30 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: tempo-mtls-selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tempo-mtls-ca
+spec:
+  isCA: true
+  commonName: tempo-mtls-ca
+  secretName: tempo-mtls-ca-secret
+  duration: 87600h # 10 years
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: tempo-mtls-selfsigned
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: tempo-mtls-ca-issuer
+spec:
+  ca:
+    secretName: tempo-mtls-ca-secret

--- a/argocd/tempo/manifests/mtls-client-cert.yaml
+++ b/argocd/tempo/manifests/mtls-client-cert.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tempo-mtls-client
+spec:
+  commonName: tempo-client
+  secretName: tempo-mtls-client-secret
+  duration: 8760h # 1 year
+  renewBefore: 720h # 30 days
+  usages:
+    - client auth
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: tempo-mtls-ca-issuer
+    kind: Issuer

--- a/argocd/tempo/manifests/onepassworditem.yaml
+++ b/argocd/tempo/manifests/onepassworditem.yaml
@@ -1,0 +1,6 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: minio-secrets
+spec:
+  itemPath: vaults/Kubernetes/items/minio-secrets

--- a/argocd/tempo/manifests/tlsoption.yaml
+++ b/argocd/tempo/manifests/tlsoption.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: tempo-mtls
+spec:
+  clientAuth:
+    secretNames:
+      - tempo-mtls-ca-secret
+    clientAuthType: RequireAndVerifyClientCert

--- a/argocd/tempo/values.yaml
+++ b/argocd/tempo/values.yaml
@@ -1,0 +1,39 @@
+global:
+  extraEnvFrom:
+    - secretRef:
+        name: minio-secrets
+
+storage:
+  trace:
+    backend: s3
+    s3:
+      access_key: "${S3_ACCESS_KEY_ID}"
+      secret_key: "${S3_SECRET_ACCESS_KEY}"
+      bucket: "tempo-traces"
+      endpoint: "minio.str08.net"
+      region: "minio-kkg-1"
+      forcepathstyle: true
+
+ingester:
+  replicas: 3
+
+gateway:
+  enabled: true
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+    hosts:
+      - host: tempo.str08.net
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - tempo.str08.net
+        secretName: tempo.str08.net-dns01
+
+metaMonitoring:
+  serviceMonitor:
+    enabled: true


### PR DESCRIPTION
- argocd/tempo/application.yaml: Tempoアプリケーションの定義を追加
- argocd/tempo/manifests/ingress-external.yaml: Tempo用の外部Ingressリソースを追加
- argocd/tempo/manifests/mtls-ca.yaml: MTLS用のCA IssuerとCertificateを追加
- argocd/tempo/manifests/mtls-client-cert.yaml: MTLSクライアント証明書を追加
- argocd/tempo/manifests/onepassworditem.yaml: MinioシークレットのOnePasswordアイテムを追加
- argocd/tempo/manifests/tlsoption.yaml: MTLSオプションを追加
- argocd/tempo/values.yaml: Tempoの設定値を追加
- argocd/minio-tenant/values.yaml: Tempoトレース用のプールを追加