### PR TITLE
refactor(values.yaml): Lokiの設定を整理

### DIFF
--- a/argocd/loki/values.yaml
+++ b/argocd/loki/values.yaml
@@ -6,6 +6,8 @@ global:
         name: minio-secrets
 
 loki:
+  commonConfig:
+    replication_factor: 1
   schemaConfig:
     configs:
       - from: "2024-04-01"
@@ -18,34 +20,27 @@ loki:
   pattern_ingester:
     enabled: true
   queryRange:
-    align_queries_with_step: true
-    split_queries_by_interval: 15m
-    cache_results: true
-    max_retries: 5
-    parallelise_shardable_queries: true
+    cache_results: false
+    max_retries: 3
+    parallelise_shardable_queries: false
   frontend:
-    max_outstanding_per_tenant: 256
+    max_outstanding_per_tenant: 64
     compress_responses: true
     log_queries_longer_than: 10s
   limits_config:
-    allow_structured_metadata: true
-    volume_enabled: true
     retention_period: 60d
-    query_timeout: 120s
-    max_query_series: 10000
-    max_query_parallelism: 32
-    max_concurrent_tail_requests: 10
-    max_label_name_length: 1024
+    query_timeout: 60s
+    split_queries_by_interval: 1h
+    max_query_series: 5000
+    max_query_parallelism: 4
+    max_concurrent_tail_requests: 5
     max_label_value_length: 4096
     max_label_names_per_series: 30
-    cardinality_limit: 100000
-    max_streams_per_user: 0
-    max_line_size: 256000
-    ingestion_rate_mb: 20
-    ingestion_burst_size_mb: 40
+    cardinality_limit: 10000
+    max_streams_per_user: 5000
+    ingestion_burst_size_mb: 8
   querier:
-    max_concurrent: 4
-    query_ingesters_within: 3h
+    max_concurrent: 2
   compactor:
     retention_enabled: true
     delete_request_store: s3
@@ -64,40 +59,38 @@ loki:
       insecure: false
       http_config: {}
 
-deploymentMode: Distributed
+deploymentMode: SingleBinary
 
 singleBinary:
-  replicas: 0
+  replicas: 1
+
 backend:
   replicas: 0
 read:
   replicas: 0
 write:
   replicas: 0
-
 ingester:
-  replicas: 3
-  zoneAwareReplication:
-    enabled: false
+  replicas: 0
 distributor:
-  replicas: 3
-  maxUnavailable: 2
+  replicas: 0
 querier:
-  replicas: 3
-  maxUnavailable: 2
+  replicas: 0
 queryFrontend:
-  replicas: 2
-  maxUnavailable: 1
+  replicas: 0
 queryScheduler:
-  replicas: 2
-  maxUnavailable: 1
+  replicas: 0
 compactor:
-  replicas: 1
+  replicas: 0
 indexGateway:
-  replicas: 2
-  maxUnavailable: 1
+  replicas: 0
 patternIngester:
-  replicas: 1
+  replicas: 0
+
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
 
 ingress:
   enabled: true


### PR DESCRIPTION
- replication_factorを1に設定
- queryRangeの設定を変更し、キャッシュを無効化、最大リトライ回数を3に設定
- frontendのmax_outstanding_per_tenantを64に変更
- limits_configの設定を見直し、query_timeoutを60sに、max_query_seriesを5000に設定
- deploymentModeをSingleBinaryに変更
- 各コンポーネントのreplicasを0または1に設定
- chunksCacheとresultsCacheを無効化