### PR TITLE
chore(renovatejob.yaml): parallelismとscheduleの設定を変更

### DIFF
--- a/flux/clusters/natsume/apps/renovate-operator/renovatejob.yaml
+++ b/flux/clusters/natsume/apps/renovate-operator/renovatejob.yaml
@@ -12,12 +12,12 @@ spec:
     - name: NODE_OPTIONS
       value: "--max-old-space-size=4096"
   image: renovate/renovate:43.104.3
-  parallelism: 3
+  parallelism: 1
   resources:
     requests:
       cpu: 100m
       memory: 512Mi
     limits:
       memory: 6Gi
-  schedule: "0 * * * *"
+  schedule: "0 */6 * * *"
   secretRef: renovate-secret


### PR DESCRIPTION
- parallelismを3から1に変更し、scheduleを"0 * * * *"から"0 */6 * * *"に変更した。