### PR TITLE
feat(cnpg-backup): cnpgバックアップ機能の追加

### DIFF
--- a/flux/clusters/natsume/apps/cnpg-backup-config/kustomization.yaml
+++ b/flux/clusters/natsume/apps/cnpg-backup-config/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- onepassworditem.yaml

--- a/flux/clusters/natsume/apps/cnpg-backup-config/onepassworditem.yaml
+++ b/flux/clusters/natsume/apps/cnpg-backup-config/onepassworditem.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cnpg-backup-flux-vars
+  namespace: flux-system
+spec:
+  itemPath: vaults/Kubernetes/items/cnpg-backup-flux-vars

--- a/flux/clusters/natsume/apps/cnpg/helmrelease-plugin-barman-cloud.yaml
+++ b/flux/clusters/natsume/apps/cnpg/helmrelease-plugin-barman-cloud.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plugin-barman-cloud
+  namespace: cnpg-system
+spec:
+  interval: 10m
+  releaseName: plugin-barman-cloud
+  targetNamespace: cnpg-system
+  install:
+    createNamespace: false
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: plugin-barman-cloud
+      version: 0.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg-repo
+        namespace: cnpg-system
+      interval: 1h

--- a/flux/clusters/natsume/apps/cnpg/kustomization.yaml
+++ b/flux/clusters/natsume/apps/cnpg/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - namespace.yaml
 - helmrepository-cloudnative-pg-repo.yaml
 - helmrelease-cnpg.yaml
+- helmrelease-plugin-barman-cloud.yaml

--- a/flux/clusters/natsume/apps/spotify-nowplaying/cluster.yaml
+++ b/flux/clusters/natsume/apps/spotify-nowplaying/cluster.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: spotify-nowplaying
 spec:
   instances: 1
+  plugins:
+  - name: barman-cloud.cloudnative-pg.io
+    isWALArchiver: true
+    parameters:
+      barmanObjectName: spn-backup-store
   storage:
     size: 5Gi
   bootstrap:

--- a/flux/clusters/natsume/apps/spotify-nowplaying/kustomization.yaml
+++ b/flux/clusters/natsume/apps/spotify-nowplaying/kustomization.yaml
@@ -6,4 +6,7 @@ resources:
 - helmrelease-spotify-nowplaying.yaml
 - cluster.yaml
 - onepassworditem.yaml
+- objectstore.yaml
+- scheduledbackup.yaml
+- onepassworditem-cnpg-backup.yaml
 - podmonitor.yaml

--- a/flux/clusters/natsume/apps/spotify-nowplaying/objectstore.yaml
+++ b/flux/clusters/natsume/apps/spotify-nowplaying/objectstore.yaml
@@ -1,0 +1,22 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: spn-backup-store
+  namespace: spotify-nowplaying
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://cnpg-backup/spn-cluster/
+    endpointURL: ${CNPG_BACKUP_ENDPOINT_URL}
+    s3Credentials:
+      accessKeyId:
+        name: cnpg-backup-s3-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: cnpg-backup-s3-secret
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: gzip
+      maxParallel: 4
+    data:
+      compression: gzip

--- a/flux/clusters/natsume/apps/spotify-nowplaying/onepassworditem-cnpg-backup.yaml
+++ b/flux/clusters/natsume/apps/spotify-nowplaying/onepassworditem-cnpg-backup.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cnpg-backup-s3-secret
+  namespace: spotify-nowplaying
+spec:
+  itemPath: vaults/Kubernetes/items/cnpg-backup-s3-secret

--- a/flux/clusters/natsume/apps/spotify-nowplaying/scheduledbackup.yaml
+++ b/flux/clusters/natsume/apps/spotify-nowplaying/scheduledbackup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: spn-cluster-daily-backup
+  namespace: spotify-nowplaying
+spec:
+  schedule: "0 20 3 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: spn-cluster
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/flux/clusters/natsume/apps/spotify-reblend/cluster.yaml
+++ b/flux/clusters/natsume/apps/spotify-reblend/cluster.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: spotify-reblend
 spec:
   instances: 1
+  plugins:
+  - name: barman-cloud.cloudnative-pg.io
+    isWALArchiver: true
+    parameters:
+      barmanObjectName: reblend-backup-store
   storage:
     size: 5Gi
   bootstrap:

--- a/flux/clusters/natsume/apps/spotify-reblend/kustomization.yaml
+++ b/flux/clusters/natsume/apps/spotify-reblend/kustomization.yaml
@@ -6,4 +6,7 @@ resources:
 - helmrelease-spotify-reblend.yaml
 - cluster.yaml
 - onepassworditem.yaml
+- objectstore.yaml
+- scheduledbackup.yaml
+- onepassworditem-cnpg-backup.yaml
 - podmonitor.yaml

--- a/flux/clusters/natsume/apps/spotify-reblend/objectstore.yaml
+++ b/flux/clusters/natsume/apps/spotify-reblend/objectstore.yaml
@@ -1,0 +1,22 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: reblend-backup-store
+  namespace: spotify-reblend
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://cnpg-backup/reblend-cluster/
+    endpointURL: ${CNPG_BACKUP_ENDPOINT_URL}
+    s3Credentials:
+      accessKeyId:
+        name: cnpg-backup-s3-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: cnpg-backup-s3-secret
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: gzip
+      maxParallel: 4
+    data:
+      compression: gzip

--- a/flux/clusters/natsume/apps/spotify-reblend/onepassworditem-cnpg-backup.yaml
+++ b/flux/clusters/natsume/apps/spotify-reblend/onepassworditem-cnpg-backup.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cnpg-backup-s3-secret
+  namespace: spotify-reblend
+spec:
+  itemPath: vaults/Kubernetes/items/cnpg-backup-s3-secret

--- a/flux/clusters/natsume/apps/spotify-reblend/scheduledbackup.yaml
+++ b/flux/clusters/natsume/apps/spotify-reblend/scheduledbackup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: reblend-cluster-daily-backup
+  namespace: spotify-reblend
+spec:
+  schedule: "0 10 3 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: reblend-cluster
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/flux/clusters/natsume/apps/sui/cluster.yaml
+++ b/flux/clusters/natsume/apps/sui/cluster.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: sui
 spec:
   instances: 1
+  plugins:
+  - name: barman-cloud.cloudnative-pg.io
+    isWALArchiver: true
+    parameters:
+      barmanObjectName: sui-backup-store
   storage:
     size: 5Gi
   bootstrap:

--- a/flux/clusters/natsume/apps/sui/kustomization.yaml
+++ b/flux/clusters/natsume/apps/sui/kustomization.yaml
@@ -5,4 +5,7 @@ resources:
 - helmrepository-sui-repo.yaml
 - helmrelease-sui.yaml
 - cluster.yaml
+- objectstore.yaml
+- scheduledbackup.yaml
+- onepassworditem-cnpg-backup.yaml
 - podmonitor.yaml

--- a/flux/clusters/natsume/apps/sui/objectstore.yaml
+++ b/flux/clusters/natsume/apps/sui/objectstore.yaml
@@ -1,0 +1,22 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: sui-backup-store
+  namespace: sui
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://cnpg-backup/sui-cluster/
+    endpointURL: ${CNPG_BACKUP_ENDPOINT_URL}
+    s3Credentials:
+      accessKeyId:
+        name: cnpg-backup-s3-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: cnpg-backup-s3-secret
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: gzip
+      maxParallel: 4
+    data:
+      compression: gzip

--- a/flux/clusters/natsume/apps/sui/onepassworditem-cnpg-backup.yaml
+++ b/flux/clusters/natsume/apps/sui/onepassworditem-cnpg-backup.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cnpg-backup-s3-secret
+  namespace: sui
+spec:
+  itemPath: vaults/Kubernetes/items/cnpg-backup-s3-secret

--- a/flux/clusters/natsume/apps/sui/scheduledbackup.yaml
+++ b/flux/clusters/natsume/apps/sui/scheduledbackup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: sui-cluster-daily-backup
+  namespace: sui
+spec:
+  schedule: "0 0 3 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: sui-cluster
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/flux/clusters/natsume/kustomization.yaml
+++ b/flux/clusters/natsume/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - kustomizations/cnpg.yaml
+- kustomizations/cnpg-backup-config.yaml
 - kustomizations/prometheus-operator-crd.yaml
 - kustomizations/cert-manager.yaml
 - kustomizations/cert-manager-config.yaml

--- a/flux/clusters/natsume/kustomizations/cnpg-backup-config.yaml
+++ b/flux/clusters/natsume/kustomizations/cnpg-backup-config.yaml
@@ -1,17 +1,19 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cnpg
+  name: cnpg-backup-config
   namespace: flux-system
 spec:
   interval: 10m
-  path: "./flux/clusters/natsume/apps/cnpg"
+  path: "./flux/clusters/natsume/apps/cnpg-backup-config"
   prune: true
   wait: true
   timeout: 10m
   sourceRef:
     kind: GitRepository
     name: flux-system
-  dependsOn:
-  - name: cert-manager
-  - name: prometheus-operator-crd
+  healthChecks:
+  - apiVersion: v1
+    kind: Secret
+    name: cnpg-backup-flux-vars
+    namespace: flux-system

--- a/flux/clusters/natsume/kustomizations/spotify-nowplaying.yaml
+++ b/flux/clusters/natsume/kustomizations/spotify-nowplaying.yaml
@@ -12,8 +12,13 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  postBuild:
+    substituteFrom:
+    - kind: Secret
+      name: cnpg-backup-flux-vars
   dependsOn:
   - name: cert-manager-config
   - name: cnpg
+  - name: cnpg-backup-config
   - name: prometheus-operator-crd
   - name: traefik

--- a/flux/clusters/natsume/kustomizations/spotify-reblend.yaml
+++ b/flux/clusters/natsume/kustomizations/spotify-reblend.yaml
@@ -12,8 +12,13 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  postBuild:
+    substituteFrom:
+    - kind: Secret
+      name: cnpg-backup-flux-vars
   dependsOn:
   - name: cert-manager-config
   - name: cnpg
+  - name: cnpg-backup-config
   - name: prometheus-operator-crd
   - name: traefik

--- a/flux/clusters/natsume/kustomizations/sui.yaml
+++ b/flux/clusters/natsume/kustomizations/sui.yaml
@@ -12,8 +12,13 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  postBuild:
+    substituteFrom:
+    - kind: Secret
+      name: cnpg-backup-flux-vars
   dependsOn:
   - name: cert-manager-config
   - name: cnpg
+  - name: cnpg-backup-config
   - name: prometheus-operator-crd
   - name: traefik-tailscale


### PR DESCRIPTION
- cnpg-backup-config用のkustomization.yamlを新規作成
- onepassworditem.yamlを新規作成し、バックアップ変数を定義
- helmrelease-plugin-barman-cloud.yamlを新規作成し、Barman Cloudプラグインを設定
- spotify-nowplayingとspotify-reblendのcluster.yamlにバックアッププラグインを追加
- objectstore.yamlを新規作成し、S3ストレージ設定を追加
- scheduledbackup.yamlを新規作成し、定期バックアップ設定を追加
- onepassworditem-cnpg-backup.yamlを新規作成し、S3認証情報を定義
- kustomization.yamlに新規リソースを追加
- 各kustomization.yamlにcnpg-backup-configを依存関係として追加