### PR TITLE
feat(traefik): デュアルスタックのIPファミリーを設定

### DIFF
--- a/flux/clusters/natsume/apps/traefik/helmrelease-traefik.yaml
+++ b/flux/clusters/natsume/apps/traefik/helmrelease-traefik.yaml
@@ -33,6 +33,10 @@ spec:
         serviceMonitor:
           enabled: true
     service:
+      ipFamilyPolicy: RequireDualStack
+      ipFamilies:
+      - IPv4
+      - IPv6
       spec:
         externalTrafficPolicy: Local
     ingressClass:


### PR DESCRIPTION
- helmrelease-traefik.yamlでサービスのipFamilyPolicyをRequireDualStackに設定し、IPv4とIPv6を指定した。