### PR TITLE
feat(flux-diff): Sticky PRコメントの依存関係を更新

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Sticky PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: flux-diff/${{ matrix.resource }}
           message: ${{ steps.comment.outputs.message }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,6 +15,7 @@
   enabledManagers: [
     'ansible',
     'ansible-galaxy',
+    'flux',
     'github-actions',
     'helmfile',
     'helm-requirements',
@@ -41,6 +42,15 @@
       commitMessageTopic: 'Helm chart {{depName}}',
       addLabels: [
         'manager:helm',
+      ],
+    },
+    {
+      matchManagers: [
+        'flux',
+      ],
+      commitMessageTopic: 'Flux {{depName}}',
+      addLabels: [
+        'manager:flux',
       ],
     },
     {
@@ -79,18 +89,6 @@
         'manager:ansible-vars',
       ],
     },
-    {
-      matchManagers: [
-        'custom.regex',
-      ],
-      matchFileNames: [
-        'argocd/**/application.yaml',
-      ],
-      commitMessageTopic: 'Argo CD chart {{depName}}',
-      addLabels: [
-        'manager:argocd',
-      ],
-    },
   ],
   customManagers: [
     {
@@ -115,18 +113,6 @@
       ],
       depNameTemplate: 'k3s-io/k3s',
       datasourceTemplate: 'github-releases',
-      versioningTemplate: 'semver',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/argocd/.+/application\\.ya?ml$/',
-      ],
-      matchStrings: [
-        '(?m)^\\s+-\\s+chart:\\s+(?<depName>[A-Za-z0-9_.\\-/]+)\\s*\\n^\\s+repoURL:\\s+(?<registryUrl>https?://[^\\s]+)\\s*\\n^\\s+targetRevision:\\s*(?<currentValue>[^\\s]+)',
-      ],
-      datasourceTemplate: 'helm',
-      registryUrlTemplate: '{{registryUrl}}',
       versioningTemplate: 'semver',
     },
   ],


### PR DESCRIPTION
- .github/workflows/flux-diff.yamlでmarocchino/sticky-pull-request-commentをv2からv3.0.4に更新
- renovate.json5にfluxマネージャーを追加し、関連するコミットメッセージトピックとラベルを設定