### PR TITLE
chore(loki): バージョンを13.6.2に更新

### DIFF
--- a/flux/clusters/natsume/apps/loki/helmrelease-loki.yaml
+++ b/flux/clusters/natsume/apps/loki/helmrelease-loki.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: loki
-      version: 7.0.0
+      version: 13.6.2
       sourceRef:
         kind: HelmRepository
         name: loki-repo

--- a/flux/clusters/natsume/apps/loki/helmrepository-loki-repo.yaml
+++ b/flux/clusters/natsume/apps/loki/helmrepository-loki-repo.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: loki
 spec:
   interval: 1h
-  url: https://grafana.github.io/helm-charts
+  url: https://grafana-community.github.io/helm-charts


### PR DESCRIPTION
- helmrelease-loki.yamlのlokiチャートのバージョンを7.0.0から13.6.2に変更
- helmrepository-loki-repo.yamlのURLをhttps://grafana.github.io/helm-chartsからhttps://grafana-community.github.io/helm-chartsに変更