### PR TITLE
feat(helmrelease-misskey): misskeyのバージョンを0.2.0に更新し、マイグレーションを有効化

### DIFF
--- a/flux/clusters/natsume/apps/misskey/helmrelease-misskey.yaml
+++ b/flux/clusters/natsume/apps/misskey/helmrelease-misskey.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     spec:
       chart: misskey
-      version: 0.1.5
+      version: 0.2.0
       sourceRef:
         kind: HelmRepository
         name: misskey-repo
@@ -54,6 +54,11 @@ spec:
 
       persistence:
         enabled: false
+
+    migration:
+      enabled: true
+      hookEvents:
+      - pre-upgrade
 
     postgresql:
       enabled: false


### PR DESCRIPTION
- misskeyのチャートバージョンを0.1.5から0.2.0に変更
- マイグレーションを有効化し、pre-upgradeフックイベントを追加