### PR TITLE
feat(helmrelease-note-tweet-connector): note-tweet-connectorのバージョンを2.…

### DIFF
--- a/flux/clusters/natsume/apps/note-tweet-connector/helmrelease-note-tweet-connector.yaml
+++ b/flux/clusters/natsume/apps/note-tweet-connector/helmrelease-note-tweet-connector.yaml
@@ -15,13 +15,15 @@ spec:
   chart:
     spec:
       chart: note-tweet-connector
-      version: 1.0.3
+      version: 2.0.0-beta.1
       sourceRef:
         kind: HelmRepository
         name: note-tweet-connector-repo
         namespace: note-tweet-connector
       interval: 1h
   values:
+    args:
+      twitterUsername: "Soli_0222"
     ingress:
       enabled: true
       className: traefik


### PR DESCRIPTION
…0.0-beta.1に更新

- note-tweet-connectorのバージョンを1.0.3から2.0.0-beta.1に変更
- twitterUsernameの引数を追加