### PR TITLE
chore(helmrelease-misskey): Bump version to 0.3.0

### DIFF
--- a/flux/clusters/natsume/apps/misskey/helmrelease-misskey.yaml
+++ b/flux/clusters/natsume/apps/misskey/helmrelease-misskey.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     spec:
       chart: misskey
-      version: 0.2.1
+      version: 0.3.0
       sourceRef:
         kind: HelmRepository
         name: misskey-repo
@@ -47,6 +47,9 @@ spec:
       extraEnv:
       - name: TZ
         value: Asia/Tokyo
+
+      diagnosticReport:
+        enabled: true
 
       image:
         repository: ghcr.io/soli0222/misskey


### PR DESCRIPTION
- helmrelease-misskey.yamlのmisskeyチャートのバージョンを0.2.1から0.3.0に更新
- diagnosticReportを有効にする設定を追加