### PR TITLE
feat(flux): switch rss-fetcher chart source to OCI on ghcr.io

### DIFF
--- a/flux/clusters/natsume/apps/rss-fetcher/helmrelease-rss-fetcher.yaml
+++ b/flux/clusters/natsume/apps/rss-fetcher/helmrelease-rss-fetcher.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: rss-fetcher
-      version: 0.3.4
+      version: 1.4.0
       sourceRef:
         kind: HelmRepository
         name: rss-fetcher-repo

--- a/flux/clusters/natsume/apps/rss-fetcher/helmrepository-rss-fetcher-repo.yaml
+++ b/flux/clusters/natsume/apps/rss-fetcher/helmrepository-rss-fetcher-repo.yaml
@@ -4,5 +4,6 @@ metadata:
   name: rss-fetcher-repo
   namespace: rss-fetcher
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts


### PR DESCRIPTION
## Summary
- rss-fetcher の Helm chart を helm-charts モノレポ(GitHub Pages)から [Soli0222/rss-fetcher](https://github.com/Soli0222/rss-fetcher) 自身のリポジトリへ移設し、リリース時に `oci://ghcr.io/soli0222/charts` へ publish するようにしました(rss-fetcher#66, リリース v1.4.0)。
- `HelmRepository` を `type: oci` / `url: oci://ghcr.io/soli0222/charts` に切り替え、`HelmRelease` の chart version を新しいバージョン(1.4.0)に更新しました。chart version は今後アプリの release タグと一致します。

## 検証済み
- ghcr 上のパッケージが public であること(匿名 pull で tag/manifest/blob 取得を確認)
- Chart.yaml の appVersion/version が CI により正しく `1.4.0` に注入されていること
- pke の values を使ったオフライン `helm template` 比較で、旧チャート(0.3.4)と新チャート(1.4.0)の差分が `helm.sh/chart`/`app.kubernetes.io/version` ラベル・config checksum・image タグ(1.3.2→1.4.0、移行PR自体がfeat:コミットだったための副次的なバージョンアップ、アプリコード変更なし)のみであること

## Test plan
- [ ] flux-diff CI (全マトリクス) green
- [ ] マージ後 `flux reconcile` で Pod が Ready になることを確認
- [ ] Renovate の次回実行で `ghcr.io/soli0222/charts/rss-fetcher` が flux manager 経由で dashboard に載ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)