### PR TITLE
feat(flux): switch 4 apps' chart sources to OCI on ghcr.io

### DIFF
--- a/flux/clusters/natsume/apps/emoji-service/helmrelease-emoji-bot-gateway.yaml
+++ b/flux/clusters/natsume/apps/emoji-service/helmrelease-emoji-bot-gateway.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: emoji-bot-gateway
-      version: 0.1.8
+      version: 1.4.0
       sourceRef:
         kind: HelmRepository
         name: emoji-bot-gateway-repo-2

--- a/flux/clusters/natsume/apps/emoji-service/helmrelease-emoji-renderer.yaml
+++ b/flux/clusters/natsume/apps/emoji-service/helmrelease-emoji-renderer.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: emoji-renderer
-      version: 0.1.3
+      version: 1.3.0
       sourceRef:
         kind: HelmRepository
         name: emoji-renderer-repo

--- a/flux/clusters/natsume/apps/emoji-service/helmrepository-emoji-bot-gateway-repo-2.yaml
+++ b/flux/clusters/natsume/apps/emoji-service/helmrepository-emoji-bot-gateway-repo-2.yaml
@@ -4,5 +4,6 @@ metadata:
   name: emoji-bot-gateway-repo-2
   namespace: emoji-service
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts

--- a/flux/clusters/natsume/apps/emoji-service/helmrepository-emoji-renderer-repo.yaml
+++ b/flux/clusters/natsume/apps/emoji-service/helmrepository-emoji-renderer-repo.yaml
@@ -4,5 +4,6 @@ metadata:
   name: emoji-renderer-repo
   namespace: emoji-service
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts

--- a/flux/clusters/natsume/apps/note-tweet-connector/helmrelease-note-tweet-connector.yaml
+++ b/flux/clusters/natsume/apps/note-tweet-connector/helmrelease-note-tweet-connector.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: note-tweet-connector
-      version: 2.2.0
+      version: 3.3.1
       sourceRef:
         kind: HelmRepository
         name: note-tweet-connector-repo

--- a/flux/clusters/natsume/apps/note-tweet-connector/helmrepository-note-tweet-connector-repo.yaml
+++ b/flux/clusters/natsume/apps/note-tweet-connector/helmrepository-note-tweet-connector-repo.yaml
@@ -4,5 +4,6 @@ metadata:
   name: note-tweet-connector-repo
   namespace: note-tweet-connector
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts

--- a/flux/clusters/natsume/apps/spotify-reblend/helmrelease-spotify-reblend.yaml
+++ b/flux/clusters/natsume/apps/spotify-reblend/helmrelease-spotify-reblend.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: spotify-reblend
-      version: 0.2.2
+      version: 1.5.0
       sourceRef:
         kind: HelmRepository
         name: spotify-reblend-repo

--- a/flux/clusters/natsume/apps/spotify-reblend/helmrepository-spotify-reblend-repo.yaml
+++ b/flux/clusters/natsume/apps/spotify-reblend/helmrepository-spotify-reblend-repo.yaml
@@ -4,5 +4,6 @@ metadata:
   name: spotify-reblend-repo
   namespace: spotify-reblend
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts


### PR DESCRIPTION
## Summary
rss-fetcher の OCI 移行(#605)に続き、以下4アプリの Helm chart を helm-charts モノレポから各アプリ自身のリポジトリへ移設し、`oci://ghcr.io/soli0222/charts` へ publish するよう切り替えました。

| app | 新 chart version | 備考 |
|---|---|---|
| emoji-renderer | 1.3.0 | |
| emoji-bot-gateway | 1.4.0 | |
| spotify-reblend | 1.5.0 | postgres は `externalPostgres`(CNPG)経由、chart 内蔵 postgres は無効化済みでレンダーに影響なし |
| note-tweet-connector | 3.3.1 | 移行途中で無関係な go.mod/Dockerfile の Go バージョン不整合を発見・修正(note-tweet-connector#133)、3.3.0→3.3.1 |

各アプリ側 PR: rss-fetcher#66 と同一パターン(emoji-renderer#169, emoji-bot-gateway#176, spotify-reblend#192, note-tweet-connector#132)。

## 検証済み
- 4アプリとも ghcr 上の chart パッケージが public(匿名 pull で確認)
- 4アプリとも `Publish Helm chart` ジョブ success

## Test plan
- [ ] flux-diff CI 全マトリクス green
- [ ] マージ後 reconcile 確認、Pod Ready
- [ ] Renovate の次回実行で4アプリとも flux manager 経由で dashboard に載ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)