### PR TITLE
feat(flux): switch spotify-nowplaying/daypassed-bot/mk-stream chart sources to OCI

### DIFF
--- a/flux/clusters/natsume/apps/daypassed-bot/helmrelease-daypassed-bot.yaml
+++ b/flux/clusters/natsume/apps/daypassed-bot/helmrelease-daypassed-bot.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: daypassed-bot
-      version: 0.1.1
+      version: 1.2.1
       sourceRef:
         kind: HelmRepository
         name: daypassed-bot-repo

--- a/flux/clusters/natsume/apps/daypassed-bot/helmrepository-daypassed-bot-repo.yaml
+++ b/flux/clusters/natsume/apps/daypassed-bot/helmrepository-daypassed-bot-repo.yaml
@@ -4,5 +4,6 @@ metadata:
   name: daypassed-bot-repo
   namespace: daypassed-bot
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts

--- a/flux/clusters/natsume/apps/mk-stream/helmrelease-mk-stream.yaml
+++ b/flux/clusters/natsume/apps/mk-stream/helmrelease-mk-stream.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: mk-stream
-      version: 1.0.0
+      version: 2.2.0
       sourceRef:
         kind: HelmRepository
         name: mk-stream-repo

--- a/flux/clusters/natsume/apps/mk-stream/helmrepository-mk-stream-repo.yaml
+++ b/flux/clusters/natsume/apps/mk-stream/helmrepository-mk-stream-repo.yaml
@@ -4,5 +4,6 @@ metadata:
   name: mk-stream-repo
   namespace: mk-stream
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts

--- a/flux/clusters/natsume/apps/spotify-nowplaying/helmrelease-spotify-nowplaying.yaml
+++ b/flux/clusters/natsume/apps/spotify-nowplaying/helmrelease-spotify-nowplaying.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: spotify-nowplaying
-      version: 3.0.5
+      version: 4.4.2
       sourceRef:
         kind: HelmRepository
         name: spotify-nowplaying-repo

--- a/flux/clusters/natsume/apps/spotify-nowplaying/helmrepository-spotify-nowplaying-repo.yaml
+++ b/flux/clusters/natsume/apps/spotify-nowplaying/helmrepository-spotify-nowplaying-repo.yaml
@@ -4,5 +4,6 @@ metadata:
   name: spotify-nowplaying-repo
   namespace: spotify-nowplaying
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts


### PR DESCRIPTION
## Summary
残り3アプリの Helm chart を helm-charts モノレポから各アプリ自身のリポジトリへ移設し、`oci://ghcr.io/soli0222/charts` へ publish するよう切り替えました。これで対象8アプリ全ての移行が完了します。

| app | 新 chart version | 備考 |
|---|---|---|
| spotify-nowplaying | 4.4.2 | chart source 切替のみ。移行中に無関係な既存バグ(go toolchain 不整合、pnpm バージョン不整合)を2件発見・修正(spotify-nowplaying#337, #339) |
| daypassed-bot | 1.2.1 | chart 内で `image.tag` が `1.0.1` に固定されていたのを解除。**実行イメージが 1.0.1 → 1.2.1 に上がります**(CronJob、daily 0:00 実行) |
| mk-stream | 2.2.0 | **イメージのレジストリが Docker Hub(`soli0222/mk-stream`)から ghcr.io(`ghcr.io/soli0222/mk-stream`)に変わり、tag 固定(`2.0.0`)も解除**。実行イメージは 2.0.0 → 2.2.0。`ghcr.io/soli0222/mk-stream:2.2.0` の linux/amd64・linux/arm64 両マニフェスト存在を事前確認済み |

各アプリ側 PR: spotify-nowplaying#335, daypassed-bot#59, mk-stream#49(いずれも rss-fetcher#66 と同一パターン)。

## 検証済み
- 3アプリとも ghcr 上の chart パッケージが public(匿名 pull で確認)
- 3アプリとも `Publish Helm chart` ジョブ success
- mk-stream の新イメージがマルチアーキ対応済みであることを `docker buildx imagetools inspect` で確認

## Test plan
- [ ] flux-diff CI 全マトリクス green(daypassed-bot・mk-stream は image タグ変更を伴うため diff に反映されるはず)
- [ ] マージ後 reconcile 確認、Pod/CronJob 正常
- [ ] daypassed-bot は手動 Job 実行で動作確認
- [ ] Renovate の次回実行で3アプリとも flux manager 経由で dashboard に載ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)