### PR TITLE
fix(flux): re-pin rss-fetcher chart to restored version lineage

### DIFF
--- a/flux/clusters/natsume/apps/rss-fetcher/helmrelease-rss-fetcher.yaml
+++ b/flux/clusters/natsume/apps/rss-fetcher/helmrelease-rss-fetcher.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: rss-fetcher
-      version: 1.4.0
+      version: 0.3.6
       sourceRef:
         kind: HelmRepository
         name: rss-fetcher-repo


### PR DESCRIPTION
rss-fetcher の chart version をアプリの release タグから切り離しました(rss-fetcher#68)。移行時に appVersion に合わせて version を 1.4.0 まで飛ばしていましたが、これを元の独立した系列(0.3.x)に復元し、以後は chart 自体の変更でのみ increment されます。

現在 ghcr に publish されている最新版 `0.3.6`(appVersion 1.4.1)に pin し直します。反映確認後、ghcr 上の旧 `1.4.0` は削除します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)