### PR TITLE
fix(flux): re-pin 7 apps' charts to restored version lineage

### DIFF
--- a/flux/clusters/natsume/apps/daypassed-bot/helmrelease-daypassed-bot.yaml
+++ b/flux/clusters/natsume/apps/daypassed-bot/helmrelease-daypassed-bot.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: daypassed-bot
-      version: 1.2.1
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: daypassed-bot-repo

--- a/flux/clusters/natsume/apps/emoji-service/helmrelease-emoji-bot-gateway.yaml
+++ b/flux/clusters/natsume/apps/emoji-service/helmrelease-emoji-bot-gateway.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: emoji-bot-gateway
-      version: 1.4.0
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: emoji-bot-gateway-repo-2

--- a/flux/clusters/natsume/apps/emoji-service/helmrelease-emoji-renderer.yaml
+++ b/flux/clusters/natsume/apps/emoji-service/helmrelease-emoji-renderer.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: emoji-renderer
-      version: 1.3.0
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: emoji-renderer-repo

--- a/flux/clusters/natsume/apps/mk-stream/helmrelease-mk-stream.yaml
+++ b/flux/clusters/natsume/apps/mk-stream/helmrelease-mk-stream.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: mk-stream
-      version: 2.2.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: mk-stream-repo

--- a/flux/clusters/natsume/apps/note-tweet-connector/helmrelease-note-tweet-connector.yaml
+++ b/flux/clusters/natsume/apps/note-tweet-connector/helmrelease-note-tweet-connector.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: note-tweet-connector
-      version: 3.3.1
+      version: 2.2.1
       sourceRef:
         kind: HelmRepository
         name: note-tweet-connector-repo

--- a/flux/clusters/natsume/apps/spotify-nowplaying/helmrelease-spotify-nowplaying.yaml
+++ b/flux/clusters/natsume/apps/spotify-nowplaying/helmrelease-spotify-nowplaying.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: spotify-nowplaying
-      version: 4.4.2
+      version: 3.0.6
       sourceRef:
         kind: HelmRepository
         name: spotify-nowplaying-repo

--- a/flux/clusters/natsume/apps/spotify-reblend/helmrelease-spotify-reblend.yaml
+++ b/flux/clusters/natsume/apps/spotify-reblend/helmrelease-spotify-reblend.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: spotify-reblend
-      version: 1.5.0
+      version: 0.2.3
       sourceRef:
         kind: HelmRepository
         name: spotify-reblend-repo


### PR DESCRIPTION
## Summary
rss-fetcher(#609)に続き、残り7アプリの chart version をアプリの release タグから切り離しました。移行時に appVersion に合わせて version を飛ばしていましたが、元の独立した系列に復元し、以後は chart 自体の変更でのみ increment されます。

| app | 旧 (誤って appVersion に揃えていた値) | 新 (復元後) | appVersion |
|---|---|---|---|
| emoji-renderer | 1.3.0 | 0.1.4 | 1.3.0 |
| emoji-bot-gateway | 1.4.0 | 0.1.9 | 1.4.0 |
| spotify-reblend | 1.5.0 | 0.2.3 | 1.5.0 |
| note-tweet-connector | 3.3.1 | 2.2.1 | 3.3.1 |
| spotify-nowplaying | 4.4.2 | 3.0.6 | 4.4.2 |
| daypassed-bot | 1.2.1 | 0.1.2 | 1.2.1 |
| mk-stream | 2.2.0 | 1.0.1 | 2.2.0 |

appVersion(＝実行イメージ)はどのアプリも変わりません。chart version の表記だけが変わります。

## Test plan
- [ ] flux-diff CI 全マトリクス green(chart version の差分のみで、image タグの差分は出ないはず)
- [ ] マージ後 reconcile 確認、Pod/CronJob 正常
- [ ] 反映後、ghcr 上の旧バージョン(appVersion に揃えていた側)を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)