### PR TITLE
ci(flux-diff): replace flux-local with flate and always render both revisions

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -4,11 +4,16 @@ on:
   pull_request:
     paths:
       - "flux/**"
+      - "charts/**"
       - ".github/workflows/flux-diff.yaml"
 
 permissions:
   contents: read
   pull-requests: write
+
+env:
+  # helm Capabilities.APIVersions。CRD が入っている前提で render する chart 用。
+  API_VERSIONS: policy/v1/PodDisruptionBudget,monitoring.coreos.com/v1
 
 jobs:
   diff:
@@ -17,33 +22,51 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [natsume, meruto]
-        resource: [helmrelease, kustomization]
+        resource: [hr, ks]
     steps:
-      - name: Ensure Flux CLI
-        shell: bash
-        run: |
-          if ! command -v flux >/dev/null 2>&1; then
-            curl -fsSL https://fluxcd.io/install.sh | sudo bash
-          fi
-          flux --version
-
-      - name: Run flux-local diff
-        id: diff
-        uses: allenporter/flux-local/action/diff@8.4.0
+      - name: Check out the PR branch
+        uses: actions/checkout@v7.0.1
         with:
-          path: flux/clusters/${{ matrix.cluster }}
-          resource: ${{ matrix.resource }}
-          live-branch: main
-          sources: flux-system=.
-          limit-bytes: 0
-          api-versions: policy/v1/PodDisruptionBudget,monitoring.coreos.com/v1
+          path: pr
+
+      - name: Check out the base branch
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: live
+
+      - name: Set up flate
+        uses: home-operations/flate/action@v0.5.0
+        with:
+          cache: true
+
+      # changed-only モード (flate の --path-orig / --base) は使わない。
+      # Kustomization の spec.path に紐づかないファイルの変更が keep set に
+      # 入らないため (home-operations/flate#833)、リポジトリ直下の
+      # charts/ を GitRepository 経由で参照している HelmRelease の変更が
+      # 無言で落ちる。両リビジョンを常にフルレンダリングして比較する。
+      - name: Render both revisions
+        env:
+          CLUSTER: ${{ matrix.cluster }}
+          RESOURCE: ${{ matrix.resource }}
+        run: |
+          set -euo pipefail
+          for side in live pr; do
+            (
+              cd "$side"
+              flate build "${RESOURCE}" \
+                --path "flux/clusters/${CLUSTER}" \
+                --api-versions "${API_VERSIONS}" \
+                --no-progress
+            ) > "${side}.yaml"
+          done
 
       - name: Compose comment
         id: comment
         env:
-          DIFF: ${{ steps.diff.outputs.diff }}
           CLUSTER: ${{ matrix.cluster }}
           RESOURCE: ${{ matrix.resource }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           GH_TOKEN: ${{ secrets.FLUX_DIFF_GIST_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
@@ -53,7 +76,8 @@ jobs:
           INLINE_LIMIT=60000
           delimiter="$(openssl rand -hex 8)"
 
-          if [[ -z "${DIFF}" ]]; then
+          if diff -u --label "live (${BASE_REF})" --label "pr" \
+              live.yaml pr.yaml > diff.patch; then
             {
               echo "message<<${delimiter}"
               echo "_\`${CLUSTER}\` の ${RESOURCE} に差分はありません。_"
@@ -62,13 +86,12 @@ jobs:
             exit 0
           fi
 
-          printf '%s' "${DIFF}" > diff.patch
           size=$(wc -c < diff.patch)
 
           if (( size <= INLINE_LIMIT )); then
             {
               echo "message<<${delimiter}"
-              echo "<details><summary>flux-local <code>${CLUSTER}</code> / <code>${RESOURCE}</code> diff (${size} bytes)</summary>"
+              echo "<details><summary>flate <code>${CLUSTER}</code> / <code>${RESOURCE}</code> diff (${size} bytes)</summary>"
               echo
               echo '```diff'
               cat diff.patch
@@ -78,11 +101,11 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           else
             gist_url=$(gh gist create diff.patch \
-              --desc "flux-local ${CLUSTER}/${RESOURCE} diff for ${REPO}#${PR_NUMBER}" \
+              --desc "flate ${CLUSTER}/${RESOURCE} diff for ${REPO}#${PR_NUMBER}" \
               | tail -n1)
             {
               echo "message<<${delimiter}"
-              echo "flux-local \`${CLUSTER}\` / \`${RESOURCE}\` diff は **${size} bytes** で 65536 字制限を超えるため Gist に退避しました: ${gist_url}"
+              echo "flate \`${CLUSTER}\` / \`${RESOURCE}\` diff は **${size} bytes** で 65536 字制限を超えるため Gist に退避しました: ${gist_url}"
               echo "${delimiter}"
             } >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Set up flate
         uses: home-operations/flate/action@v0.5.0
         with:
+          base: ""
           cache: true
 
       # changed-only モード (flate の --path-orig / --base) は使わない。
@@ -51,6 +52,9 @@ jobs:
           RESOURCE: ${{ matrix.resource }}
         run: |
           set -euo pipefail
+          # setup-flate は base 入力 (既定はデフォルトブランチ) を FLATE_BASE として
+          # export する。これが残っていると changed-only モードに落ちるので外す。
+          unset FLATE_BASE
           for side in live pr; do
             (
               cd "$side"


### PR DESCRIPTION
## なぜ

helm-charts 廃止 (Phase 2) で pke 本体の `charts/` を Flux の `GitRepository` から参照する形に切り替えようとしたところ、**flux-local が GitRepository 参照の chart をレンダリングできない**ことが判明した。

#612 の CI ログ:

```
WARNING:flux_local.helm:Unable to find chart flux-system-flux-system/./charts/blackbox-exporter-probes ...
INFO:flux_local.visitor:Skipping HelmRelease blackbox-exporter-probes with invalid path flux-system-flux-system
```

対象 HelmRelease が **PR 側・live 側の両方で無言でスキップ**され、meruto の helmrelease diff は Probe が全部消える差分になった。

原因はコードで確認済み。`flux-local diff` は旧 visitor 経路を使い、`HelmVisitor.repos` の型が `HelmRepository | OCIRepository` に限られている。GitRepository を解決する `LocalGitRepository` は新 orchestrator 経路 (`build` / `get`) にしか存在しない。`--sources` は Kustomization の path 解決用で、この経路には効かない。**設定では回避できない。**

加えて flux-local は **8.4.0 を最後に sunset 済み**で、実行時に deprecation warning を出す。

このまま Phase 2 を進めると、misskey・mimir・navidrome・distribution など複雑な chart が**恒久的に flux-diff の対象外**になる。

## 何を変えたか

後継の [flate](https://github.com/home-operations/flate) (Go 実装、flux-local の作者が移行先として案内しているもの) に載せ替えた。

### changed-only モードは使わない

flate には `--path-orig` / `--base` による changed-only モードがあるが、**使っていない**。変更ファイルを Flux Kustomization の `spec.path` へ遡って帰属させる仕組みのため、リポジトリ直下の `charts/` はどの `spec.path` にも一致せず keep set が空になる。既知の open issue [home-operations/flate#833](https://github.com/home-operations/flate/issues/833) と同じ根本原因。

実測で確認した:

```
level=DEBUG msg="changed-only mode" changed_files=1
level=DEBUG msg="changed-only keep set" size=0 items=[]
level=DEBUG msg="reconcile complete" kustomizations=21 helm_releases=0
```

chart のテンプレートを変更しても差分が空で返る。これは renovate が `charts/*/values.yaml` の image tag を上げる経路そのものなので、見逃すと痛い。

代わりに **base と PR の両リビジョンを常にフルレンダリングして `diff -u`** で比較する。changed-only より遅いが、帰属ヒューリスティックに依存しないので死角が無い。

### その他

- `strip-attrs` 相当のノイズ除去は**行わない**。`helm.sh/chart` や `app.kubernetes.io/version` の変化は実際にクラスタへ適用される変更なので、安全網としては隠さず出す。chart bump のたびに数行のラベル差分が増えるが、それは正確な表示。
- `live` 側は `main` 固定ではなく PR の base ref を使う
- trigger paths に `charts/**` を追加
- レンダリングに失敗したら job を落とす (「差分ゼロ」と区別する)

## 検証

ローカルで flate 0.5.0 を実行して確認した。

| 確認 | 結果 |
|---|---|
| GitRepository 参照の chart のレンダリング | Probe 3 + PrometheusRule 1 を正しく展開 |
| #612 の chart source 切替 (main vs PR) | **差分ゼロ** — 移設が no-op であることの証明 |
| chart テンプレートだけを変更 | **検出される** (changed-only では検出できなかったもの) |
| 出力の決定性 | 同一入力で2回実行しバイト一致 |
| 全マトリクス (natsume/meruto × hr/ks) | 全て exit 0、レンダリングエラー無し |
| 所要時間 | 1クラスタ1リソースあたり数秒 |

## 注意

- flate は v0.5.0 と若い。ただし flux-local が sunset 済みである以上、この移行はいずれ必要だった。
- pke の `main` にはそもそも branch protection が無いので、「required check」は現状 GitHub 側では強制されていない。Phase 2 の切替 PR では**マージ前に差分ゼロを目視で確認する**運用にする。