### PR TITLE
feat(charts): move navidrome chart into pke and switch to GitRepository

### DIFF
--- a/charts/navidrome/Chart.yaml
+++ b/charts/navidrome/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: navidrome
+description: A Helm chart for Navidrome - A modern Music Server and Streamer
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 2.5.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+
+# renovate: image=deluan/navidrome
+appVersion: "0.63.2"

--- a/charts/navidrome/README.md
+++ b/charts/navidrome/README.md
@@ -1,0 +1,200 @@
+# navidrome
+
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.63.2](https://img.shields.io/badge/AppVersion-0.63.2-informational?style=flat-square)
+
+A Helm chart for Navidrome - A modern Music Server and Streamer
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| config.address | string | `""` |  |
+| config.agents | string | `"lastfm,deezer"` |  |
+| config.albumPlayCountMode | string | `"absolute"` |  |
+| config.artistArtPriority | string | `"artist.*, album/artist.*, external"` |  |
+| config.artistImageFolder | string | `""` |  |
+| config.authRequestLimit | int | `5` |  |
+| config.authWindowLength | string | `"20s"` |  |
+| config.autoImportPlaylists | bool | `true` |  |
+| config.autoTranscodeDownload | bool | `false` |  |
+| config.backup.count | int | `0` |  |
+| config.backup.path | string | `""` |  |
+| config.backup.schedule | string | `""` |  |
+| config.baseUrl | string | `""` |  |
+| config.cacheFolder | string | `""` |  |
+| config.coverArtPriority | string | `"cover.*, folder.*, front.*, embedded, external"` |  |
+| config.coverArtQuality | int | `75` |  |
+| config.dataFolder | string | `"/data"` |  |
+| config.deezer.enabled | bool | `true` |  |
+| config.deezer.language | string | `"en"` |  |
+| config.defaultDownloadableShare | bool | `false` |  |
+| config.defaultDownsamplingFormat | string | `"opus"` |  |
+| config.defaultLanguage | string | `"ja"` |  |
+| config.defaultPlaylistPublicVisibility | bool | `false` |  |
+| config.defaultShareExpiration | string | `"8760h"` |  |
+| config.defaultTheme | string | `"Dark"` |  |
+| config.defaultUIVolume | int | `100` |  |
+| config.discArtPriority | string | `"disc*.*, cd*.*, dvd*.*"` |  |
+| config.enableArtworkPrecache | bool | `true` |  |
+| config.enableArtworkUpload | bool | `true` |  |
+| config.enableCoverAnimation | bool | `true` |  |
+| config.enableDownloads | bool | `true` |  |
+| config.enableExternalServices | bool | `true` |  |
+| config.enableFavourites | bool | `true` |  |
+| config.enableGravatar | bool | `false` |  |
+| config.enableInsightsCollector | bool | `true` |  |
+| config.enableLogRedacting | bool | `true` |  |
+| config.enableM3UExternalAlbumArt | bool | `false` |  |
+| config.enableMediaFileCoverArt | bool | `true` |  |
+| config.enableNowPlaying | bool | `true` |  |
+| config.enableReplayGain | bool | `true` |  |
+| config.enableScrobbleHistory | bool | `true` |  |
+| config.enableSharing | bool | `true` |  |
+| config.enableStarRating | bool | `true` |  |
+| config.enableTranscodingConfig | bool | `false` |  |
+| config.enableUserEditing | bool | `true` |  |
+| config.enableWebPEncoding | bool | `false` |  |
+| config.enabled | bool | `true` |  |
+| config.enforceNonRootUser | bool | `false` |  |
+| config.extAuth.logoutURL | string | `""` |  |
+| config.extAuth.trustedSources | string | `""` |  |
+| config.extAuth.userHeader | string | `"Remote-User"` |  |
+| config.ffmpegPath | string | `""` |  |
+| config.gaTrackingID | string | `""` |  |
+| config.httpHeaders.frameOptions | string | `"DENY"` |  |
+| config.ignoredArticles | string | `"The El La Los Las Le Les Os As O A"` |  |
+| config.imageCacheSize | string | `"100MB"` |  |
+| config.inspect.backlogLimit | int | `100` |  |
+| config.inspect.backlogTimeout | int | `60000000000` |  |
+| config.inspect.enabled | bool | `true` |  |
+| config.inspect.maxRequests | int | `1` |  |
+| config.jukebox.adminOnly | bool | `true` |  |
+| config.jukebox.default | string | `""` |  |
+| config.jukebox.devices | list | `[]` |  |
+| config.jukebox.enabled | bool | `false` |  |
+| config.lastfm.apiKey | string | `""` |  |
+| config.lastfm.enabled | bool | `true` |  |
+| config.lastfm.language | string | `"en"` |  |
+| config.lastfm.scrobbleFirstArtistOnly | bool | `false` |  |
+| config.lastfm.secret | string | `""` |  |
+| config.listenBrainz.baseURL | string | `"https://api.listenbrainz.org/1/"` |  |
+| config.listenBrainz.enabled | bool | `true` |  |
+| config.logFile | string | `""` |  |
+| config.logLevel | string | `"info"` |  |
+| config.lyricsPriority | string | `".ttml,.yaml,.yml,.elrc,.lrc,.srt,.txt,embedded"` |  |
+| config.matcher.fuzzyThreshold | int | `85` |  |
+| config.matcher.preferStarred | bool | `true` |  |
+| config.maxImageUploadSize | string | `"10MB"` |  |
+| config.maxSidebarPlaylists | int | `100` |  |
+| config.mpvCmdTemplate | string | `"mpv --audio-device=%d --no-audio-display %f --input-ipc-server=%s"` |  |
+| config.mpvPath | string | `""` |  |
+| config.musicFolder | string | `"/music"` |  |
+| config.passwordEncryptionKey | string | `""` |  |
+| config.pid.album | string | `"musicbrainz_albumid|albumartistid,album,albumversion,releasedate"` |  |
+| config.pid.track | string | `"musicbrainz_trackid|albumid,discnumber,tracknumber,title"` |  |
+| config.playlistsPath | string | `""` |  |
+| config.plugins.autoReload | bool | `false` |  |
+| config.plugins.cacheSize | string | `"200MB"` |  |
+| config.plugins.enabled | bool | `true` |  |
+| config.plugins.folder | string | `""` |  |
+| config.plugins.logLevel | string | `""` |  |
+| config.port | int | `4533` |  |
+| config.preferSortTags | bool | `false` |  |
+| config.prometheus.enabled | bool | `true` |  |
+| config.prometheus.metricsPath | string | `"/metrics"` |  |
+| config.prometheus.password | string | `""` |  |
+| config.recentlyAddedByModTime | bool | `false` |  |
+| config.scanner.artistJoiner | string | `" • "` |  |
+| config.scanner.artistSplitExceptions | list | `[]` |  |
+| config.scanner.enabled | bool | `true` |  |
+| config.scanner.followSymlinks | bool | `true` |  |
+| config.scanner.ignoreDotFolders | bool | `true` |  |
+| config.scanner.purgeMissing | string | `"never"` |  |
+| config.scanner.scanOnStartup | bool | `true` |  |
+| config.scanner.schedule | string | `"0"` |  |
+| config.scanner.watcherWait | string | `"5s"` |  |
+| config.search.backend | string | `"fts"` |  |
+| config.search.fullString | bool | `false` |  |
+| config.sessionTimeout | string | `"48h"` |  |
+| config.shareURL | string | `""` |  |
+| config.smartPlaylistRefreshDelay | string | `"5s"` |  |
+| config.subsonic.appendAlbumVersion | bool | `true` |  |
+| config.subsonic.appendSubtitle | bool | `true` |  |
+| config.subsonic.artistParticipations | bool | `false` |  |
+| config.subsonic.defaultReportRealPath | bool | `false` |  |
+| config.subsonic.enableAverageRating | bool | `true` |  |
+| config.subsonic.legacyClients | string | `"DSub"` |  |
+| config.tags | object | `{}` |  |
+| config.tlsCert | string | `""` |  |
+| config.tlsKey | string | `""` |  |
+| config.transcoding.enableCancellation | bool | `false` |  |
+| config.transcoding.maxConcurrent | int | `0` |  |
+| config.transcoding.maxConcurrentPerUser | int | `0` |  |
+| config.transcodingCacheSize | string | `"100MB"` |  |
+| config.uiCoverArtSize | int | `300` |  |
+| config.uiLoginBackgroundUrl | string | `""` |  |
+| config.uiPlaybackReportInterval | string | `"1m"` |  |
+| config.uiSearchDebounceMs | int | `250` |  |
+| config.uiWelcomeMessage | string | `""` |  |
+| config.unixSocketPerm | string | `"0660"` |  |
+| containerPort | int | `4533` |  |
+| env | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"deluan/navidrome"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.blockedPaths | list | `[]` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `true` |  |
+| ingress.hosts[0].host | string | `"example.tld"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| livenessProbe | object | `{}` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| persistence.data.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| persistence.data.enabled | bool | `true` |  |
+| persistence.data.existingClaim | string | `""` |  |
+| persistence.data.size | string | `"10Gi"` |  |
+| persistence.data.storageClass | string | `""` |  |
+| persistence.music.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| persistence.music.createPv | bool | `false` |  |
+| persistence.music.enabled | bool | `true` |  |
+| persistence.music.existingClaim | string | `""` |  |
+| persistence.music.existingVolume | string | `""` |  |
+| persistence.music.nfs.mountOptions[0] | string | `"nfsvers=4.1"` |  |
+| persistence.music.nfs.path | string | `""` |  |
+| persistence.music.nfs.server | string | `""` |  |
+| persistence.music.size | string | `"50Gi"` |  |
+| persistence.music.storageClass | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| readinessProbe | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.port | int | `4533` |  |
+| service.targetPort | int | `4533` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor.annotations | object | `{}` |  |
+| serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.interval | string | `"30s"` |  |
+| serviceMonitor.jobLabel | string | `""` |  |
+| serviceMonitor.labels | object | `{}` |  |
+| serviceMonitor.metricRelabelings | list | `[]` |  |
+| serviceMonitor.namespace | string | `""` |  |
+| serviceMonitor.relabelings | list | `[]` |  |
+| serviceMonitor.scrapeTimeout | string | `"10s"` |  |
+| serviceMonitor.selector | object | `{}` |  |
+| tolerations | list | `[]` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/navidrome/templates/NOTES.txt
+++ b/charts/navidrome/templates/NOTES.txt
@@ -1,0 +1,33 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "navidrome.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "navidrome.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "navidrome.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "{{ include "navidrome.selectorLabels" . | replace ": " "=" | replace "\n" "," }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+
+2. Navidrome Configuration:
+   - Music library path: /music
+   - Data directory: /data
+   - Default language: {{ .Values.config.defaultLanguage }}
+   - Scan schedule: {{ .Values.config.scanSchedule }}
+   
+3. First time setup:
+   - Access the web interface using the URL above
+   - Create your admin user account
+   - The music library will be automatically scanned based on the configured schedule

--- a/charts/navidrome/templates/_helpers.tpl
+++ b/charts/navidrome/templates/_helpers.tpl
@@ -1,0 +1,102 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "navidrome.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "navidrome.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "navidrome.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "navidrome.labels" -}}
+helm.sh/chart: {{ include "navidrome.chart" . }}
+{{ include "navidrome.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "navidrome.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "navidrome.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "navidrome.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "navidrome.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Data PVC name - maintain existing naming for backward compatibility
+*/}}
+{{- define "navidrome.dataPvcName" -}}
+{{- if .Values.persistence.data.existingClaim }}
+{{- .Values.persistence.data.existingClaim }}
+{{- else }}
+{{- printf "%s-data-pvc" (include "navidrome.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Music PVC name - maintain existing naming for backward compatibility  
+*/}}
+{{- define "navidrome.musicPvcName" -}}
+{{- if .Values.persistence.music.existingClaim }}
+{{- .Values.persistence.music.existingClaim }}
+{{- else }}
+{{- printf "%s-music-pvc" (include "navidrome.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Music PV name - maintain existing naming for backward compatibility
+*/}}
+{{- define "navidrome.musicPvName" -}}
+{{- if .Values.persistence.music.existingVolume }}
+{{- .Values.persistence.music.existingVolume }}
+{{- else }}
+{{- printf "%s-music-pv" (include "navidrome.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Ingress block service name
+*/}}
+{{- define "navidrome.ingressBlockServiceName" -}}
+{{- printf "%s-ingress-block" (include "navidrome.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/navidrome/templates/configmap.yaml
+++ b/charts/navidrome/templates/configmap.yaml
@@ -1,0 +1,497 @@
+{{- if .Values.config.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "navidrome.fullname" . }}-config
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+data:
+  navidrome.toml: |
+    # Navidrome Configuration File
+    # See https://www.navidrome.org/docs/usage/configuration-options/#available-options
+    
+    # Basic configuration
+    {{- with .Values.config.musicFolder }}
+    MusicFolder = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.dataFolder }}
+    DataFolder = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.cacheFolder }}
+    CacheFolder = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.logLevel }}
+    LogLevel = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.logFile }}
+    LogFile = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.address }}
+    Address = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.baseUrl }}
+    BaseUrl = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.port }}
+    Port = {{ . }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableInsightsCollector" }}
+    EnableInsightsCollector = {{ .Values.config.enableInsightsCollector }}
+    {{- end }}
+    {{- if hasKey .Values.config "enforceNonRootUser" }}
+    EnforceNonRootUser = {{ .Values.config.enforceNonRootUser }}
+    {{- end }}
+    
+    # Advanced configuration
+    {{- with .Values.config.agents }}
+    Agents = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.albumPlayCountMode }}
+    AlbumPlayCountMode = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.authRequestLimit }}
+    AuthRequestLimit = {{ . }}
+    {{- end }}
+    {{- with .Values.config.authWindowLength }}
+    AuthWindowLength = {{ . | quote }}
+    {{- end }}
+    {{- if hasKey .Values.config "autoImportPlaylists" }}
+    AutoImportPlaylists = {{ .Values.config.autoImportPlaylists }}
+    {{- end }}
+    {{- if hasKey .Values.config "autoTranscodeDownload" }}
+    AutoTranscodeDownload = {{ .Values.config.autoTranscodeDownload }}
+    {{- end }}
+    {{- if hasKey .Values.config "defaultPlaylistPublicVisibility" }}
+    DefaultPlaylistPublicVisibility = {{ .Values.config.defaultPlaylistPublicVisibility }}
+    {{- end }}
+    {{- with .Values.config.artistArtPriority }}
+    ArtistArtPriority = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.artistImageFolder }}
+    ArtistImageFolder = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.coverArtPriority }}
+    CoverArtPriority = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.coverArtQuality }}
+    CoverArtQuality = {{ . }}
+    {{- end }}
+    {{- with .Values.config.discArtPriority }}
+    DiscArtPriority = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.defaultDownsamplingFormat }}
+    DefaultDownsamplingFormat = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.defaultLanguage }}
+    DefaultLanguage = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.defaultTheme }}
+    DefaultTheme = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.defaultShareExpiration }}
+    DefaultShareExpiration = {{ . | quote }}
+    {{- end }}
+    {{- if hasKey .Values.config "defaultDownloadableShare" }}
+    DefaultDownloadableShare = {{ .Values.config.defaultDownloadableShare }}
+    {{- end }}
+    {{- with .Values.config.defaultUIVolume }}
+    DefaultUIVolume = {{ . }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableArtworkPrecache" }}
+    EnableArtworkPrecache = {{ .Values.config.enableArtworkPrecache }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableArtworkUpload" }}
+    EnableArtworkUpload = {{ .Values.config.enableArtworkUpload }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableCoverAnimation" }}
+    EnableCoverAnimation = {{ .Values.config.enableCoverAnimation }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableWebPEncoding" }}
+    EnableWebPEncoding = {{ .Values.config.enableWebPEncoding }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableDownloads" }}
+    EnableDownloads = {{ .Values.config.enableDownloads }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableExternalServices" }}
+    EnableExternalServices = {{ .Values.config.enableExternalServices }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableFavourites" }}
+    EnableFavourites = {{ .Values.config.enableFavourites }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableGravatar" }}
+    EnableGravatar = {{ .Values.config.enableGravatar }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableLogRedacting" }}
+    EnableLogRedacting = {{ .Values.config.enableLogRedacting }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableM3UExternalAlbumArt" }}
+    EnableM3UExternalAlbumArt = {{ .Values.config.enableM3UExternalAlbumArt }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableMediaFileCoverArt" }}
+    EnableMediaFileCoverArt = {{ .Values.config.enableMediaFileCoverArt }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableNowPlaying" }}
+    EnableNowPlaying = {{ .Values.config.enableNowPlaying }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableReplayGain" }}
+    EnableReplayGain = {{ .Values.config.enableReplayGain }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableScrobbleHistory" }}
+    EnableScrobbleHistory = {{ .Values.config.enableScrobbleHistory }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableSharing" }}
+    EnableSharing = {{ .Values.config.enableSharing }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableStarRating" }}
+    EnableStarRating = {{ .Values.config.enableStarRating }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableTranscodingConfig" }}
+    EnableTranscodingConfig = {{ .Values.config.enableTranscodingConfig }}
+    {{- end }}
+    {{- if hasKey .Values.config "enableUserEditing" }}
+    EnableUserEditing = {{ .Values.config.enableUserEditing }}
+    {{- end }}
+    {{- with .Values.config.ffmpegPath }}
+    FFmpegPath = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.gaTrackingID }}
+    GATrackingID = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.ignoredArticles }}
+    IgnoredArticles = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.imageCacheSize }}
+    ImageCacheSize = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.lyricsPriority }}
+    LyricsPriority = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.maxImageUploadSize }}
+    MaxImageUploadSize = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.maxSidebarPlaylists }}
+    MaxSidebarPlaylists = {{ . }}
+    {{- end }}
+    {{- with .Values.config.mpvPath }}
+    MPVPath = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.mpvCmdTemplate }}
+    MPVCmdTemplate = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.passwordEncryptionKey }}
+    PasswordEncryptionKey = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.playlistsPath }}
+    PlaylistsPath = {{ . | quote }}
+    {{- end }}
+    {{- if hasKey .Values.config "preferSortTags" }}
+    PreferSortTags = {{ .Values.config.preferSortTags }}
+    {{- end }}
+    {{- if hasKey .Values.config "recentlyAddedByModTime" }}
+    RecentlyAddedByModTime = {{ .Values.config.recentlyAddedByModTime }}
+    {{- end }}
+    {{- with .Values.config.sessionTimeout }}
+    SessionTimeout = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.shareURL }}
+    ShareURL = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.smartPlaylistRefreshDelay }}
+    SmartPlaylistRefreshDelay = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.tlsCert }}
+    TLSCert = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.tlsKey }}
+    TLSKey = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.transcodingCacheSize }}
+    TranscodingCacheSize = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.uiLoginBackgroundUrl }}
+    UILoginBackgroundUrl = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.uiPlaybackReportInterval }}
+    UIPlaybackReportInterval = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.uiSearchDebounceMs }}
+    UISearchDebounceMs = {{ . }}
+    {{- end }}
+    {{- with .Values.config.uiWelcomeMessage }}
+    UIWelcomeMessage = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.uiCoverArtSize }}
+    UICoverArtSize = {{ . }}
+    {{- end }}
+    {{- with .Values.config.unixSocketPerm }}
+    UnixSocketPerm = {{ . | quote }}
+    {{- end }}
+    
+    # Backup configuration
+    {{- with .Values.config.backup.path }}
+    [Backup]
+    Path = {{ . | quote }}
+    {{- with $.Values.config.backup.schedule }}
+    Schedule = {{ . | quote }}
+    {{- end }}
+    {{- with $.Values.config.backup.count }}
+    Count = {{ . }}
+    {{- end }}
+    {{- end }}
+    
+    # Deezer configuration
+    {{- if or (hasKey .Values.config.deezer "enabled") .Values.config.deezer.language }}
+    [Deezer]
+    {{- if hasKey .Values.config.deezer "enabled" }}
+    Enabled = {{ .Values.config.deezer.enabled }}
+    {{- end }}
+    {{- with .Values.config.deezer.language }}
+    Language = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    
+    # ExtAuth configuration
+    {{- if or .Values.config.extAuth.trustedSources .Values.config.extAuth.userHeader .Values.config.extAuth.logoutURL }}
+    [ExtAuth]
+    {{- with .Values.config.extAuth.trustedSources }}
+    TrustedSources = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.extAuth.userHeader }}
+    UserHeader = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.extAuth.logoutURL }}
+    LogoutURL = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    
+    # HTTP Headers
+    {{- with .Values.config.httpHeaders.frameOptions }}
+    [HTTPHeaders]
+    FrameOptions = {{ . | quote }}
+    {{- end }}
+    
+    # Inspect configuration
+    {{- if or (hasKey .Values.config.inspect "enabled") .Values.config.inspect.backlogLimit .Values.config.inspect.backlogTimeout .Values.config.inspect.maxRequests }}
+    [Inspect]
+    {{- if hasKey .Values.config.inspect "enabled" }}
+    Enabled = {{ .Values.config.inspect.enabled }}
+    {{- end }}
+    {{- with .Values.config.inspect.backlogLimit }}
+    BacklogLimit = {{ . }}
+    {{- end }}
+    {{- with .Values.config.inspect.backlogTimeout }}
+    BacklogTimeout = {{ printf "%.0f" (float64 .) | int64 }}
+    {{- end }}
+    {{- with .Values.config.inspect.maxRequests }}
+    MaxRequests = {{ . }}
+    {{- end }}
+    {{- end }}
+    
+    # Jukebox configuration
+    {{- if or (hasKey .Values.config.jukebox "enabled") (hasKey .Values.config.jukebox "adminOnly") .Values.config.jukebox.default }}
+    [Jukebox]
+    {{- if hasKey .Values.config.jukebox "enabled" }}
+    Enabled = {{ .Values.config.jukebox.enabled }}
+    {{- end }}
+    {{- if hasKey .Values.config.jukebox "adminOnly" }}
+    AdminOnly = {{ .Values.config.jukebox.adminOnly }}
+    {{- end }}
+    {{- with .Values.config.jukebox.default }}
+    Default = {{ . | quote }}
+    {{- end }}
+    {{- range .Values.config.jukebox.devices }}
+    [[Jukebox.Devices]]
+    {{- with .name }}
+    Name = {{ . | quote }}
+    {{- end }}
+    {{- with .audioDevice }}
+    AudioDevice = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    
+    # Last.fm configuration
+    {{- if or (hasKey .Values.config.lastfm "enabled") .Values.config.lastfm.apiKey .Values.config.lastfm.secret .Values.config.lastfm.language (hasKey .Values.config.lastfm "scrobbleFirstArtistOnly") }}
+    [LastFM]
+    {{- if hasKey .Values.config.lastfm "enabled" }}
+    Enabled = {{ .Values.config.lastfm.enabled }}
+    {{- end }}
+    {{- with .Values.config.lastfm.apiKey }}
+    ApiKey = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.lastfm.secret }}
+    Secret = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.lastfm.language }}
+    Language = {{ . | quote }}
+    {{- end }}
+    {{- if hasKey .Values.config.lastfm "scrobbleFirstArtistOnly" }}
+    ScrobbleFirstArtistOnly = {{ .Values.config.lastfm.scrobbleFirstArtistOnly }}
+    {{- end }}
+    {{- end }}
+    
+    # ListenBrainz configuration
+    {{- if or .Values.config.listenBrainz.baseURL (hasKey .Values.config.listenBrainz "enabled") }}
+    [ListenBrainz]
+    {{- with .Values.config.listenBrainz.baseURL }}
+    BaseURL = {{ . | quote }}
+    {{- end }}
+    {{- if hasKey .Values.config.listenBrainz "enabled" }}
+    Enabled = {{ .Values.config.listenBrainz.enabled }}
+    {{- end }}
+    {{- end }}
+
+    # Matcher configuration
+    {{- $matcher := .Values.config.matcher | default dict }}
+    {{- if or (hasKey $matcher "fuzzyThreshold") (hasKey $matcher "preferStarred") }}
+    [Matcher]
+    {{- if hasKey $matcher "fuzzyThreshold" }}
+    FuzzyThreshold = {{ $matcher.fuzzyThreshold }}
+    {{- end }}
+    {{- if hasKey $matcher "preferStarred" }}
+    PreferStarred = {{ $matcher.preferStarred }}
+    {{- end }}
+    {{- end }}
+    
+    # PID configuration
+    {{- if or .Values.config.pid.album .Values.config.pid.track }}
+    [PID]
+    {{- with .Values.config.pid.album }}
+    Album = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.pid.track }}
+    Track = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    
+    # Plugins configuration
+    {{- if or (hasKey .Values.config.plugins "enabled") .Values.config.plugins.folder (hasKey .Values.config.plugins "autoReload") .Values.config.plugins.logLevel .Values.config.plugins.cacheSize }}
+    [Plugins]
+    {{- if hasKey .Values.config.plugins "enabled" }}
+    Enabled = {{ .Values.config.plugins.enabled }}
+    {{- end }}
+    {{- with .Values.config.plugins.folder }}
+    Folder = {{ . | quote }}
+    {{- end }}
+    {{- if hasKey .Values.config.plugins "autoReload" }}
+    AutoReload = {{ .Values.config.plugins.autoReload }}
+    {{- end }}
+    {{- with .Values.config.plugins.logLevel }}
+    LogLevel = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.plugins.cacheSize }}
+    CacheSize = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    
+    # Prometheus configuration
+    {{- if or (hasKey .Values.config.prometheus "enabled") .Values.config.prometheus.metricsPath .Values.config.prometheus.password }}
+    [Prometheus]
+    {{- if hasKey .Values.config.prometheus "enabled" }}
+    Enabled = {{ .Values.config.prometheus.enabled }}
+    {{- end }}
+    {{- with .Values.config.prometheus.metricsPath }}
+    MetricsPath = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.prometheus.password }}
+    Password = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    
+    # Scanner configuration
+    {{- if or (hasKey .Values.config.scanner "enabled") .Values.config.scanner.schedule .Values.config.scanner.watcherWait (hasKey .Values.config.scanner "scanOnStartup") .Values.config.scanner.artistJoiner .Values.config.scanner.artistSplitExceptions (hasKey .Values.config.scanner "followSymlinks") (hasKey .Values.config.scanner "ignoreDotFolders") .Values.config.scanner.purgeMissing }}
+    [Scanner]
+    {{- if hasKey .Values.config.scanner "enabled" }}
+    Enabled = {{ .Values.config.scanner.enabled }}
+    {{- end }}
+    {{- with .Values.config.scanner.schedule }}
+    Schedule = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.scanner.watcherWait }}
+    WatcherWait = {{ . | quote }}
+    {{- end }}
+    {{- if hasKey .Values.config.scanner "scanOnStartup" }}
+    ScanOnStartup = {{ .Values.config.scanner.scanOnStartup }}
+    {{- end }}
+    {{- with .Values.config.scanner.artistJoiner }}
+    ArtistJoiner = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.scanner.artistSplitExceptions }}
+    ArtistSplitExceptions = [{{ range $i, $e := . }}{{ if $i }}, {{ end }}{{ $e | quote }}{{ end }}]
+    {{- end }}
+    {{- if hasKey .Values.config.scanner "followSymlinks" }}
+    FollowSymlinks = {{ .Values.config.scanner.followSymlinks }}
+    {{- end }}
+    {{- if hasKey .Values.config.scanner "ignoreDotFolders" }}
+    IgnoreDotFolders = {{ .Values.config.scanner.ignoreDotFolders }}
+    {{- end }}
+    {{- with .Values.config.scanner.purgeMissing }}
+    PurgeMissing = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+
+    # Search configuration
+    {{- if or .Values.config.search.backend .Values.config.search.fullString }}
+    [Search]
+    {{- with .Values.config.search.backend }}
+    Backend = {{ . | quote }}
+    {{- end }}
+    {{- if hasKey .Values.config.search "fullString" }}
+    FullString = {{ .Values.config.search.fullString }}
+    {{- end }}
+    {{- end }}
+
+    # Subsonic configuration
+    {{- if or (hasKey .Values.config.subsonic "appendSubtitle") (hasKey .Values.config.subsonic "appendAlbumVersion") (hasKey .Values.config.subsonic "artistParticipations") (hasKey .Values.config.subsonic "defaultReportRealPath") (hasKey .Values.config.subsonic "enableAverageRating") .Values.config.subsonic.legacyClients }}
+    [Subsonic]
+    {{- if hasKey .Values.config.subsonic "appendSubtitle" }}
+    AppendSubtitle = {{ .Values.config.subsonic.appendSubtitle }}
+    {{- end }}
+    {{- if hasKey .Values.config.subsonic "appendAlbumVersion" }}
+    AppendAlbumVersion = {{ .Values.config.subsonic.appendAlbumVersion }}
+    {{- end }}
+    {{- if hasKey .Values.config.subsonic "artistParticipations" }}
+    ArtistParticipations = {{ .Values.config.subsonic.artistParticipations }}
+    {{- end }}
+    {{- if hasKey .Values.config.subsonic "defaultReportRealPath" }}
+    DefaultReportRealPath = {{ .Values.config.subsonic.defaultReportRealPath }}
+    {{- end }}
+    {{- if hasKey .Values.config.subsonic "enableAverageRating" }}
+    EnableAverageRating = {{ .Values.config.subsonic.enableAverageRating }}
+    {{- end }}
+    {{- with .Values.config.subsonic.legacyClients }}
+    LegacyClients = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+
+    # Transcoding configuration
+    {{- $transcoding := .Values.config.transcoding | default dict }}
+    {{- if or (hasKey $transcoding "enableCancellation") (hasKey $transcoding "maxConcurrent") (hasKey $transcoding "maxConcurrentPerUser") }}
+    [Transcoding]
+    {{- if hasKey $transcoding "enableCancellation" }}
+    EnableCancellation = {{ $transcoding.enableCancellation }}
+    {{- end }}
+    {{- if hasKey $transcoding "maxConcurrent" }}
+    MaxConcurrent = {{ $transcoding.maxConcurrent }}
+    {{- end }}
+    {{- if hasKey $transcoding "maxConcurrentPerUser" }}
+    MaxConcurrentPerUser = {{ $transcoding.maxConcurrentPerUser }}
+    {{- end }}
+    {{- end }}
+    
+    # Tags configuration
+    {{- if .Values.config.tags }}
+    {{- range $name, $tag := .Values.config.tags }}
+    [Tags.{{ $name }}]
+    {{- with $tag.aliases }}
+    Aliases = [{{ range $i, $a := . }}{{ if $i }}, {{ end }}{{ $a | quote }}{{ end }}]
+    {{- end }}
+    {{- with $tag.split }}
+    Split = [{{ range $i, $s := . }}{{ if $i }}, {{ end }}{{ $s | quote }}{{ end }}]
+    {{- end }}
+    {{- with $tag.type }}
+    Type = {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/navidrome/templates/data-pvc.yaml
+++ b/charts/navidrome/templates/data-pvc.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "navidrome.dataPvcName" . }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.data.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | quote }}
+  {{- if .Values.persistence.data.storageClass }}
+  {{- if (eq "-" .Values.persistence.data.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.data.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/navidrome/templates/deployment.yaml
+++ b/charts/navidrome/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "navidrome.fullname" . }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "navidrome.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.config.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "navidrome.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "navidrome.serviceAccountName" . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.persistence.data.enabled }}
+            - name: data
+              mountPath: /data
+            {{- end }}
+            {{- if .Values.persistence.music.enabled }}
+            - name: music
+              mountPath: /music
+              readOnly: true
+            {{- end }}
+            {{- if .Values.config.enabled }}
+            - name: config
+              mountPath: /data/navidrome.toml
+              subPath: navidrome.toml
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if .Values.persistence.data.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "navidrome.dataPvcName" . }}
+        {{- end }}
+        {{- if .Values.persistence.music.enabled }}
+        - name: music
+          persistentVolumeClaim:
+            claimName: {{ include "navidrome.musicPvcName" . }}
+        {{- end }}
+        {{- if .Values.config.enabled }}
+        - name: config
+          configMap:
+            name: {{ include "navidrome.fullname" . }}-config
+        {{- end }}

--- a/charts/navidrome/templates/ingress-block-service.yaml
+++ b/charts/navidrome/templates/ingress-block-service.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.ingress.enabled .Values.ingress.blockedPaths }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "navidrome.ingressBlockServiceName" . }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+{{- end }}

--- a/charts/navidrome/templates/ingress.yaml
+++ b/charts/navidrome/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "navidrome.fullname" . }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range $.Values.ingress.blockedPaths }}
+          - path: {{ .path }}
+            {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "navidrome.ingressBlockServiceName" $ }}
+                port:
+                  name: http
+          {{- end }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "navidrome.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/navidrome/templates/music-pvc.yaml
+++ b/charts/navidrome/templates/music-pvc.yaml
@@ -1,0 +1,54 @@
+{{- if and .Values.persistence.music.enabled (not .Values.persistence.music.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "navidrome.musicPvcName" . }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.music.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.music.size | quote }}
+  {{- if .Values.persistence.music.storageClass }}
+  {{- if (eq "-" .Values.persistence.music.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.music.storageClass | quote }}
+  {{- end }}
+  {{- else if .Values.persistence.music.existingVolume }}
+  storageClassName: ""
+  {{- end }}
+  {{- if .Values.persistence.music.existingVolume }}
+  volumeName: {{ .Values.persistence.music.existingVolume }}
+  {{- end }}
+{{- end }}
+
+---
+
+{{- if and .Values.persistence.music.enabled .Values.persistence.music.createPv (not .Values.persistence.music.existingVolume) }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "navidrome.musicPvName" . }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+spec:
+  capacity:
+    storage: {{ .Values.persistence.music.size | quote }}
+  accessModes:
+    {{- range .Values.persistence.music.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  persistentVolumeReclaimPolicy: Retain
+  {{- if .Values.persistence.music.nfs.mountOptions }}
+  mountOptions:
+    {{- toYaml .Values.persistence.music.nfs.mountOptions | nindent 4 }}
+  {{- end }}
+  nfs:
+    server: {{ .Values.persistence.music.nfs.server | quote }}
+    path: {{ .Values.persistence.music.nfs.path | quote }}
+{{- end }}

--- a/charts/navidrome/templates/prometheus-secret.yaml
+++ b/charts/navidrome/templates/prometheus-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.config.prometheus.enabled .Values.config.prometheus.password .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "navidrome.fullname" . }}-prometheus-auth
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  username: "navidrome"
+  password: {{ .Values.config.prometheus.password | quote }}
+{{- end }}

--- a/charts/navidrome/templates/service.yaml
+++ b/charts/navidrome/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "navidrome.fullname" . }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "navidrome.selectorLabels" . | nindent 4 }}

--- a/charts/navidrome/templates/serviceaccount.yaml
+++ b/charts/navidrome/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "navidrome.serviceAccountName" . }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/navidrome/templates/servicemonitor.yaml
+++ b/charts/navidrome/templates/servicemonitor.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.config.prometheus.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "navidrome.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "navidrome.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "navidrome.selectorLabels" . | nindent 6 }}
+      {{- with .Values.serviceMonitor.selector }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  endpoints:
+    - port: http
+      {{- if .Values.config.prometheus.metricsPath }}
+      path: {{ .Values.config.prometheus.metricsPath }}
+      {{- else }}
+      path: /metrics
+      {{- end }}
+      {{- if .Values.config.prometheus.password }}
+      basicAuth:
+        username:
+          name: {{ include "navidrome.fullname" . }}-prometheus-auth
+          key: username
+        password:
+          name: {{ include "navidrome.fullname" . }}-prometheus-auth
+          key: password
+      {{- end }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/navidrome/values.yaml
+++ b/charts/navidrome/values.yaml
@@ -1,0 +1,379 @@
+# Default values for navidrome.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Application metadata
+nameOverride: ""
+fullnameOverride: ""
+
+# Image configuration
+image:
+  repository: deluan/navidrome
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Service account configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Pod security context
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# Container security context
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# Deployment configuration
+replicaCount: 1
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 4533
+  targetPort: 4533
+
+# Application port configuration
+containerPort: 4533
+
+# Resource limits and requests
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Node selection
+nodeSelector: {}
+
+# Tolerations
+tolerations: []
+
+# Affinity
+affinity: {}
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod labels
+podLabels: {}
+
+# Persistence configuration
+persistence:
+  # Data volume configuration
+  data:
+    enabled: true
+    # Use existing PVC (if specified, no new PVC will be created)
+    existingClaim: ""
+    # Storage class for the PVC
+    storageClass: ""
+    # Storage size
+    size: 10Gi
+    # Access modes
+    accessModes:
+      - ReadWriteOnce
+  
+  # Music volume configuration
+  music:
+    enabled: true
+    # Use existing PVC (if specified, no new PVC will be created)
+    existingClaim: ""
+    # Use existing PV (if specified, no new PV will be created)
+    existingVolume: ""
+    # Create PV (set to false to only create PVC)
+    createPv: false
+    # Storage class for the PVC (use "-" for empty storageClassName)
+    storageClass: ""
+    # Storage size
+    size: 50Gi
+    # Access modes
+    accessModes:
+      - ReadWriteOnce
+    # NFS configuration (for PV creation, only used when createPv is true)
+    nfs:
+      server: ""
+      path: ""
+      # NFS version and mount options
+      mountOptions:
+        - nfsvers=4.1
+
+# Ingress configuration
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # Paths to return no backend endpoint for, useful for hiding internal endpoints
+  # from public ingress while keeping them available through the ClusterIP service.
+  blockedPaths: []
+    # - path: /metrics
+    #   pathType: Exact
+  hosts:
+    - host: example.tld
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: navidrome-tls
+  #    hosts:
+  #      - example.tld
+
+# ServiceMonitor configuration (requires Prometheus Operator)
+serviceMonitor:
+  # Enable ServiceMonitor creation
+  enabled: false
+  # Namespace to create ServiceMonitor in (defaults to release namespace)
+  namespace: ""
+  # Additional labels for ServiceMonitor
+  labels: {}
+  # Annotations for ServiceMonitor
+  annotations: {}
+  # Job label for ServiceMonitor
+  jobLabel: ""
+  # Additional selector labels
+  selector: {}
+  # Scrape interval
+  interval: "30s"
+  # Scrape timeout
+  scrapeTimeout: "10s"
+  # Relabelings
+  relabelings: []
+  # Metric relabelings
+  metricRelabelings: []
+
+# Application configuration
+config:
+  # Enable ConfigMap-based configuration
+  enabled: true
+  
+  # Basic configuration
+  musicFolder: "/music"
+  dataFolder: "/data"
+  cacheFolder: ""  # defaults to <DataFolder>/cache
+  logLevel: "info"
+  logFile: ""  # empty means log to stderr
+  address: ""  # defaults to 0.0.0.0 and ::
+  baseUrl: ""
+  port: 4533
+  enableInsightsCollector: true
+  enforceNonRootUser: false
+  
+  # Advanced configuration
+  agents: "lastfm,deezer"
+  albumPlayCountMode: "absolute"
+  authRequestLimit: 5
+  authWindowLength: "20s"
+  autoImportPlaylists: true
+  autoTranscodeDownload: false
+  defaultPlaylistPublicVisibility: false
+  artistArtPriority: "artist.*, album/artist.*, external"
+  artistImageFolder: ""  # empty means use default
+  coverArtPriority: "cover.*, folder.*, front.*, embedded, external"
+  coverArtQuality: 75
+  discArtPriority: "disc*.*, cd*.*, dvd*.*"
+  defaultDownsamplingFormat: "opus"
+  defaultLanguage: "ja"
+  defaultTheme: "Dark"
+  defaultShareExpiration: "8760h"  # 1 year
+  defaultDownloadableShare: false
+  defaultUIVolume: 100
+  enableArtworkPrecache: true
+  enableArtworkUpload: true
+  enableCoverAnimation: true
+  enableWebPEncoding: false
+  enableDownloads: true
+  enableExternalServices: true
+  enableFavourites: true
+  enableGravatar: false
+  enableLogRedacting: true
+  enableM3UExternalAlbumArt: false
+  enableMediaFileCoverArt: true
+  enableNowPlaying: true
+  enableReplayGain: true
+  enableScrobbleHistory: true
+  enableSharing: true
+  enableStarRating: true
+  enableTranscodingConfig: false
+  enableUserEditing: true
+  ffmpegPath: ""  # empty means search in PATH
+  gaTrackingID: ""
+  ignoredArticles: "The El La Los Las Le Les Os As O A"
+  imageCacheSize: "100MB"
+  lyricsPriority: ".ttml,.yaml,.yml,.elrc,.lrc,.srt,.txt,embedded"
+  maxImageUploadSize: "10MB"
+  maxSidebarPlaylists: 100
+  mpvPath: ""  # empty means search in PATH
+  mpvCmdTemplate: "mpv --audio-device=%d --no-audio-display %f --input-ipc-server=%s"
+  passwordEncryptionKey: ""
+  playlistsPath: ""  # empty means any playlist files in library
+  preferSortTags: false
+  recentlyAddedByModTime: false
+  sessionTimeout: "48h"
+  shareURL: ""  # empty means use server address
+  smartPlaylistRefreshDelay: "5s"
+  tlsCert: ""  # empty means disable TLS
+  tlsKey: ""  # empty means disable TLS
+  transcodingCacheSize: "100MB"
+  uiLoginBackgroundUrl: ""  # empty means random from Unsplash collection
+  uiPlaybackReportInterval: "1m"
+  uiSearchDebounceMs: 250
+  uiWelcomeMessage: ""
+  uiCoverArtSize: 300
+  unixSocketPerm: "0660"
+  
+  # Backup configuration
+  backup:
+    path: ""  # empty means disabled
+    schedule: ""  # empty means disabled
+    count: 0  # 0 means disabled
+  
+  # Deezer configuration
+  deezer:
+    enabled: true
+    language: "en"
+  
+  # ExtAuth configuration
+  extAuth:
+    trustedSources: ""  # empty means deny all
+    userHeader: "Remote-User"
+    logoutURL: ""
+  
+  # HTTP Headers
+  httpHeaders:
+    frameOptions: "DENY"
+  
+  # Inspect configuration
+  inspect:
+    enabled: true
+    backlogLimit: 100
+    backlogTimeout: 60000000000  # 1 minute in nanoseconds (Go time.Minute)
+    maxRequests: 1
+  
+  # Jukebox configuration
+  jukebox:
+    enabled: false
+    adminOnly: true
+    default: ""  # empty means auto detect
+    devices: []
+    # Example:
+    # - name: "My Device"
+    #   audioDevice: "hw:0,0"
+  
+  # Last.fm configuration
+  lastfm:
+    enabled: true
+    apiKey: ""
+    secret: ""
+    language: "en"
+    scrobbleFirstArtistOnly: false
+  
+  # ListenBrainz configuration
+  listenBrainz:
+    baseURL: "https://api.listenbrainz.org/1/"
+    enabled: true
+
+  # Matcher configuration
+  matcher:
+    fuzzyThreshold: 85
+    preferStarred: true
+  
+  # PID configuration
+  pid:
+    album: "musicbrainz_albumid|albumartistid,album,albumversion,releasedate"
+    track: "musicbrainz_trackid|albumid,discnumber,tracknumber,title"
+  
+  # Plugins configuration
+  plugins:
+    enabled: true
+    folder: ""  # empty means <DataFolder>/plugins
+    autoReload: false
+    logLevel: ""  # empty means use main LogLevel
+    cacheSize: "200MB"
+  
+  # Prometheus configuration
+  prometheus:
+    enabled: true
+    metricsPath: "/metrics"
+    password: ""  # empty means no authentication
+  
+  # Scanner configuration
+  scanner:
+    enabled: true
+    schedule: "0"  # 0 means disabled, use cron syntax otherwise
+    watcherWait: "5s"
+    scanOnStartup: true
+    artistJoiner: " • "
+    # Artist names that must never be split by tag separators
+    # Example:
+    # artistSplitExceptions:
+    #   - "Tyler, The Creator"
+    artistSplitExceptions: []
+    followSymlinks: true
+    ignoreDotFolders: true  # false means also index folders whose name starts with a dot
+    purgeMissing: "never"  # possible values: "never", "always", "full"
+
+  # Search configuration
+  search:
+    backend: "fts"
+    fullString: false
+
+  # Subsonic configuration
+  subsonic:
+    appendSubtitle: true
+    appendAlbumVersion: true
+    artistParticipations: false
+    defaultReportRealPath: false
+    enableAverageRating: true
+    legacyClients: "DSub"
+
+  # Transcoding configuration
+  transcoding:
+    enableCancellation: false
+    maxConcurrent: 0
+    maxConcurrentPerUser: 0
+  
+  # Tags configuration (custom tags to import from music files)
+  # Example:
+  # tags:
+  #   genre:
+  #     aliases:
+  #       - "TCON"
+  #     split: ";/"
+  tags: {}
+
+# Additional environment variables (not from secrets)
+env: []
+# - name: EXAMPLE_VAR
+#   value: "example-value"
+
+# Health checks
+livenessProbe: {}
+  # httpGet:
+  #   path: /
+  #   port: http
+  # initialDelaySeconds: 30
+  # periodSeconds: 10
+
+readinessProbe: {}
+  # httpGet:
+  #   path: /
+  #   port: http
+  # initialDelaySeconds: 5
+  #   periodSeconds: 5

--- a/flux/clusters/meruto/apps/navidrome/helmrelease-navidrome.yaml
+++ b/flux/clusters/meruto/apps/navidrome/helmrelease-navidrome.yaml
@@ -14,12 +14,11 @@ spec:
     crds: CreateReplace
   chart:
     spec:
-      chart: navidrome
-      version: 2.5.0
+      chart: ./charts/navidrome
       sourceRef:
-        kind: HelmRepository
-        name: navidrome-repo
-        namespace: navidrome
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
       interval: 1h
   values:
     replicaCount: 1

--- a/flux/clusters/meruto/apps/navidrome/helmrepository-navidrome-repo.yaml
+++ b/flux/clusters/meruto/apps/navidrome/helmrepository-navidrome-repo.yaml
@@ -1,8 +1,0 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: navidrome-repo
-  namespace: navidrome
-spec:
-  interval: 1h
-  url: https://soli0222.github.io/helm-charts

--- a/flux/clusters/meruto/apps/navidrome/kustomization.yaml
+++ b/flux/clusters/meruto/apps/navidrome/kustomization.yaml
@@ -4,5 +4,4 @@ resources:
 - namespace.yaml
 - pv-music.yaml
 - ciliumnetworkpolicy.yaml
-- helmrepository-navidrome-repo.yaml
 - helmrelease-navidrome.yaml


### PR DESCRIPTION
Phase 2 の2件目 (パイロットは #612)。

helm-charts の gh-pages 配布をやめ、chart を pke 本体の `charts/` に持たせて Flux の `GitRepository` (flux-system) から直接参照する。

- `charts/navidrome/` を helm-charts から移設 (published `navidrome-2.5.0` と templates/values が完全一致することを確認済み)
- HelmRelease の chart source を `HelmRepository` → `GitRepository` に変更 (GitRepository source では `version` は解決に使われないため削除)
- gh-pages を指す `HelmRepository` を削除し `kustomization.yaml` からも外す

**hr の diff が差分ゼロであることを確認してからマージする** (レンダリング結果が変わらない = Pod が再起動しない)。