### PR TITLE
feat(charts): move mimir chart into pke and switch to GitRepository

### DIFF
--- a/charts/mimir/Chart.yaml
+++ b/charts/mimir/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: mimir
+description: A Helm chart for Grafana Mimir running in monolithic mode
+type: application
+version: 0.1.6
+
+# renovate: image=docker.io/grafana/mimir
+appVersion: "3.1.4"

--- a/charts/mimir/README.md
+++ b/charts/mimir/README.md
@@ -1,0 +1,75 @@
+# mimir
+
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.2](https://img.shields.io/badge/AppVersion-3.1.2-informational?style=flat-square)
+
+A Helm chart for Grafana Mimir running in monolithic mode
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity |
+| env | list | `[]` | Environment variables added to the Mimir container |
+| envFrom | list | `[]` | envFrom entries added to the Mimir container. Use this to expose object storage credentials such as AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from an existing Secret. |
+| extraArgs | object | `{}` | Extra command-line arguments appended as `-key=value` |
+| extraVolumeMounts | list | `[]` | Additional volume mounts added to the Mimir container |
+| extraVolumes | list | `[]` | Additional volumes added to the Pod |
+| fullnameOverride | string | `""` | Override the full name of the chart |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"grafana/mimir","tag":""}` | Image configuration |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"grafana/mimir"` | Grafana Mimir image repository |
+| image.tag | string | `""` | Grafana Mimir image tag. Defaults to the chart appVersion when empty. |
+| imagePullSecrets | list | `[]` | Image pull secrets |
+| ingresses | list | `[]` | Ingress definitions. Because monolithic Mimir exposes a single HTTP endpoint, each ingress backend always points to the main Service HTTP port. |
+| livenessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/ready","port":"http"},"initialDelaySeconds":45,"periodSeconds":15,"timeoutSeconds":5}` | Liveness probe configuration |
+| memberlistService | object | `{"annotations":{},"port":7946}` | Headless memberlist Service configuration |
+| memberlistService.annotations | object | `{}` | Memberlist Service annotations |
+| memberlistService.port | int | `7946` | Memberlist port exposed by the headless Service and container |
+| mimir | object | `{"config":"target: all\nmultitenancy_enabled: false\n\ncommon:\n  storage:\n    backend: s3\n    s3:\n      endpoint: s3.example.com\n      region: us-east-1\n      access_key_id: ${AWS_ACCESS_KEY_ID}\n      secret_access_key: ${AWS_SECRET_ACCESS_KEY}\n      insecure: false\n\nblocks_storage:\n  s3:\n    bucket_name: mimir-blocks\n  bucket_store:\n    sync_dir: /data/tsdb-sync\n  tsdb:\n    dir: /data/tsdb\n    head_compaction_interval: 15m\n    wal_replay_concurrency: 3\n\ncompactor:\n  data_dir: /data/compactor\n  sharding_ring:\n    kvstore:\n      store: memberlist\n\ndistributor:\n  ring:\n    kvstore:\n      store: memberlist\n\ningester:\n  ring:\n    replication_factor: {{ .Values.replicaCount }}\n    kvstore:\n      store: memberlist\n\nstore_gateway:\n  sharding_ring:\n    replication_factor: {{ .Values.replicaCount }}\n    kvstore:\n      store: memberlist\n\nlimits:\n  compactor_blocks_retention_period: 60d\n  max_global_series_per_user: 1000000\n  ingestion_rate: 50000\n  ingestion_burst_size: 1000000\n  out_of_order_time_window: 5m\n\nmemberlist:\n  bind_port: {{ .Values.memberlistService.port }}\n  abort_if_cluster_join_fails: false\n  join_members:\n    - dnssrv+{{ include \"mimir.memberlistServiceName\" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.memberlistService.port }}\n\nserver:\n  http_listen_port: {{ .Values.service.httpPort }}\n  grpc_listen_port: {{ .Values.service.grpcPort }}\n  log_level: info\n","structuredConfig":{}}` | Mimir configuration. This string is rendered with `tpl`, then merged with `mimir.structuredConfig`. |
+| mimir.config | string | `"target: all\nmultitenancy_enabled: false\n\ncommon:\n  storage:\n    backend: s3\n    s3:\n      endpoint: s3.example.com\n      region: us-east-1\n      access_key_id: ${AWS_ACCESS_KEY_ID}\n      secret_access_key: ${AWS_SECRET_ACCESS_KEY}\n      insecure: false\n\nblocks_storage:\n  s3:\n    bucket_name: mimir-blocks\n  bucket_store:\n    sync_dir: /data/tsdb-sync\n  tsdb:\n    dir: /data/tsdb\n    head_compaction_interval: 15m\n    wal_replay_concurrency: 3\n\ncompactor:\n  data_dir: /data/compactor\n  sharding_ring:\n    kvstore:\n      store: memberlist\n\ndistributor:\n  ring:\n    kvstore:\n      store: memberlist\n\ningester:\n  ring:\n    replication_factor: {{ .Values.replicaCount }}\n    kvstore:\n      store: memberlist\n\nstore_gateway:\n  sharding_ring:\n    replication_factor: {{ .Values.replicaCount }}\n    kvstore:\n      store: memberlist\n\nlimits:\n  compactor_blocks_retention_period: 60d\n  max_global_series_per_user: 1000000\n  ingestion_rate: 50000\n  ingestion_burst_size: 1000000\n  out_of_order_time_window: 5m\n\nmemberlist:\n  bind_port: {{ .Values.memberlistService.port }}\n  abort_if_cluster_join_fails: false\n  join_members:\n    - dnssrv+{{ include \"mimir.memberlistServiceName\" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.memberlistService.port }}\n\nserver:\n  http_listen_port: {{ .Values.service.httpPort }}\n  grpc_listen_port: {{ .Values.service.grpcPort }}\n  log_level: info\n"` | Base Mimir config rendered into `mimir.yaml`. Prefer official config keys here. |
+| mimir.structuredConfig | object | `{}` | Structured overrides merged on top of `mimir.config`. Use this to add official config blocks such as `ruler_storage` or `alertmanager_storage` without copying the whole config. |
+| nameOverride | string | `""` | Override the name of the chart |
+| nodeSelector | object | `{}` | Node selector |
+| persistence | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":true,"existingClaim":"","size":"10Gi","storageClass":""}` | Persistent storage configuration for WAL, TSDB state, and compactor data |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | PVC access modes |
+| persistence.annotations | object | `{}` | PVC annotations |
+| persistence.enabled | bool | `true` | Enable persistent storage. Disable to use emptyDir. |
+| persistence.existingClaim | string | `""` | Use an existing PVC instead of creating a per-pod volume claim. Best suited for single replica deployments. |
+| persistence.size | string | `"10Gi"` | PVC size |
+| persistence.storageClass | string | `""` | PVC storage class |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podManagementPolicy | string | `"OrderedReady"` | Pod management policy for the StatefulSet |
+| podSecurityContext | object | `{}` | Pod security context |
+| readinessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/ready","port":"http"},"initialDelaySeconds":15,"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe configuration |
+| replicaCount | int | `1` | Number of Mimir replicas. When using classic monolithic mode, align ring replication factors with this value. |
+| resources | object | `{"limits":{"memory":"2Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | Resource requests and limits |
+| securityContext | object | `{}` | Container security context |
+| service | object | `{"annotations":{},"grpcPort":9095,"httpPort":8080,"type":"ClusterIP"}` | Service configuration |
+| service.annotations | object | `{}` | Service annotations |
+| service.grpcPort | int | `9095` | gRPC port exposed by the main Service and container |
+| service.httpPort | int | `8080` | HTTP port exposed by the main Service and container |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount | object | `{"annotations":{},"create":false,"name":""}` | Service account configuration |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use |
+| serviceMonitor | object | `{"annotations":{},"enabled":false,"interval":"30s","jobLabel":"","labels":{},"metricRelabelings":[],"namespace":"","path":"/metrics","relabelings":[],"scrapeTimeout":"10s","selector":{}}` | ServiceMonitor configuration |
+| serviceMonitor.annotations | object | `{}` | Annotations added to the ServiceMonitor |
+| serviceMonitor.enabled | bool | `false` | Enable creation of a ServiceMonitor |
+| serviceMonitor.interval | string | `"30s"` | Scrape interval |
+| serviceMonitor.jobLabel | string | `""` | Optional jobLabel |
+| serviceMonitor.labels | object | `{}` | Labels added to the ServiceMonitor |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabelings for the ServiceMonitor endpoint |
+| serviceMonitor.namespace | string | `""` | Namespace for the ServiceMonitor. Defaults to the release namespace when empty. |
+| serviceMonitor.path | string | `"/metrics"` | Metrics path |
+| serviceMonitor.relabelings | list | `[]` | Relabelings for the ServiceMonitor endpoint |
+| serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout |
+| serviceMonitor.selector | object | `{}` | Extra matchLabels added to the ServiceMonitor selector |
+| startupProbe | object | `{"failureThreshold":60,"httpGet":{"path":"/ready","port":"http"},"periodSeconds":10,"timeoutSeconds":5}` | Startup probe configuration |
+| terminationGracePeriodSeconds | int | `180` | Termination grace period in seconds |
+| tolerations | list | `[]` | Tolerations |
+| topologySpreadConstraints | list | `[]` | Topology spread constraints |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/mimir/templates/NOTES.txt
+++ b/charts/mimir/templates/NOTES.txt
@@ -1,0 +1,8 @@
+1. Grafana Mimir is available on the HTTP Service:
+   http://{{ include "mimir.fullname" . }}:{{ .Values.service.httpPort }}
+
+2. Prometheus remote_write endpoint:
+   http://{{ include "mimir.fullname" . }}:{{ .Values.service.httpPort }}/api/v1/push
+
+3. Grafana datasource URL:
+   http://{{ include "mimir.fullname" . }}:{{ .Values.service.httpPort }}/prometheus

--- a/charts/mimir/templates/_helpers.tpl
+++ b/charts/mimir/templates/_helpers.tpl
@@ -1,0 +1,96 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mimir.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mimir.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mimir.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mimir.labels" -}}
+helm.sh/chart: {{ include "mimir.chart" . }}
+{{ include "mimir.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mimir.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mimir.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mimir.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mimir.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+ConfigMap name
+*/}}
+{{- define "mimir.configMapName" -}}
+{{- printf "%s-config" (include "mimir.fullname" .) }}
+{{- end }}
+
+{{/*
+Headless memberlist service name
+*/}}
+{{- define "mimir.memberlistServiceName" -}}
+{{- printf "%s-memberlist" (include "mimir.fullname" .) }}
+{{- end }}
+
+{{/*
+Storage PVC name when using an existing claim
+*/}}
+{{- define "mimir.storageClaimName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- printf "%s-data" (include "mimir.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render and merge the base config with structured overrides.
+*/}}
+{{- define "mimir.renderedConfig" -}}
+{{- $base := tpl .Values.mimir.config . | fromYaml -}}
+{{- $merged := mergeOverwrite (deepCopy $base) .Values.mimir.structuredConfig -}}
+{{- toYaml $merged -}}
+{{- end }}

--- a/charts/mimir/templates/configmap.yaml
+++ b/charts/mimir/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mimir.configMapName" . }}
+  labels:
+    {{- include "mimir.labels" . | nindent 4 }}
+data:
+  mimir.yaml: |
+    {{- include "mimir.renderedConfig" . | nindent 4 }}

--- a/charts/mimir/templates/ingress.yaml
+++ b/charts/mimir/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- range .Values.ingresses }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "mimir.labels" $ | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "mimir.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.httpPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/mimir/templates/memberlist-service.yaml
+++ b/charts/mimir/templates/memberlist-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.memberlistServiceName" . }}
+  labels:
+    {{- include "mimir.labels" . | nindent 4 }}
+  {{- with .Values.memberlistService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: memberlist
+      port: {{ .Values.memberlistService.port }}
+      targetPort: memberlist
+      protocol: TCP
+  selector:
+    {{- include "mimir.selectorLabels" . | nindent 4 }}

--- a/charts/mimir/templates/service.yaml
+++ b/charts/mimir/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.fullname" . }}
+  labels:
+    {{- include "mimir.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "mimir.selectorLabels" . | nindent 4 }}

--- a/charts/mimir/templates/serviceaccount.yaml
+++ b/charts/mimir/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mimir.serviceAccountName" . }}
+  labels:
+    {{- include "mimir.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mimir/templates/servicemonitor.yaml
+++ b/charts/mimir/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mimir.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "mimir.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" . | nindent 6 }}
+      {{- with .Values.serviceMonitor.selector }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/mimir/templates/statefulset.yaml
+++ b/charts/mimir/templates/statefulset.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "mimir.fullname" . }}
+  labels:
+    {{- include "mimir.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "mimir.memberlistServiceName" . }}
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  selector:
+    matchLabels:
+      {{- include "mimir.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "mimir.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mimir
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "mimir.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: mimir
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-config.expand-env=true"
+            {{- range $key, $value := .Values.extraArgs }}
+            - "-{{ $key }}={{ $value }}"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.httpPort }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.service.grpcPort }}
+              protocol: TCP
+            - name: memberlist
+              containerPort: {{ .Values.memberlistService.port }}
+              protocol: TCP
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir/mimir.yaml
+              subPath: mimir.yaml
+            - name: storage
+              mountPath: /data
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mimir.configMapName" . }}
+        {{- if .Values.persistence.existingClaim }}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ include "mimir.storageClaimName" . }}
+        {{- else if not .Values.persistence.enabled }}
+        - name: storage
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        {{- with .Values.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+  {{- end }}

--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -1,0 +1,247 @@
+# Default values for mimir.
+
+# -- Override the name of the chart
+nameOverride: ""
+# -- Override the full name of the chart
+fullnameOverride: ""
+
+# -- Image configuration
+image:
+  # -- Grafana Mimir image repository
+  repository: grafana/mimir
+  # -- Grafana Mimir image tag. Defaults to the chart appVersion when empty.
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets
+imagePullSecrets: []
+
+# -- Service account configuration
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: false
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use
+  name: ""
+
+# -- Pod annotations
+podAnnotations: {}
+# -- Pod labels
+podLabels: {}
+
+# -- Pod security context
+podSecurityContext: {}
+# -- Container security context
+securityContext: {}
+
+# -- Number of Mimir replicas. When using classic monolithic mode, align ring replication factors with this value.
+replicaCount: 1
+# -- Pod management policy for the StatefulSet
+podManagementPolicy: OrderedReady
+# -- Termination grace period in seconds
+terminationGracePeriodSeconds: 180
+
+# -- Service configuration
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service annotations
+  annotations: {}
+  # -- HTTP port exposed by the main Service and container
+  httpPort: 8080
+  # -- gRPC port exposed by the main Service and container
+  grpcPort: 9095
+
+# -- Headless memberlist Service configuration
+memberlistService:
+  # -- Memberlist Service annotations
+  annotations: {}
+  # -- Memberlist port exposed by the headless Service and container
+  port: 7946
+
+# -- Persistent storage configuration for WAL, TSDB state, and compactor data
+persistence:
+  # -- Enable persistent storage. Disable to use emptyDir.
+  enabled: true
+  # -- Use an existing PVC instead of creating a per-pod volume claim. Best suited for single replica deployments.
+  existingClaim: ""
+  # -- PVC annotations
+  annotations: {}
+  # -- PVC storage class
+  storageClass: ""
+  # -- PVC access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- PVC size
+  size: 10Gi
+
+# -- Environment variables added to the Mimir container
+env: []
+# -- envFrom entries added to the Mimir container. Use this to expose object storage credentials such as AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from an existing Secret.
+envFrom: []
+# -- Extra command-line arguments appended as `-key=value`
+extraArgs: {}
+# -- Additional volumes added to the Pod
+extraVolumes: []
+# -- Additional volume mounts added to the Mimir container
+extraVolumeMounts: []
+
+# -- Resource requests and limits
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    memory: 2Gi
+
+# -- Node selector
+nodeSelector: {}
+# -- Tolerations
+tolerations: []
+# -- Affinity
+affinity: {}
+# -- Topology spread constraints
+topologySpreadConstraints: []
+
+# -- Startup probe configuration
+startupProbe:
+  httpGet:
+    path: /ready
+    port: http
+  failureThreshold: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+# -- Liveness probe configuration
+livenessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 45
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+# -- Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+# -- Ingress definitions. Because monolithic Mimir exposes a single HTTP endpoint, each ingress backend always points to the main Service HTTP port.
+ingresses: []
+  # - name: mimir
+  #   className: traefik
+  #   annotations:
+  #     cert-manager.io/cluster-issuer: letsencrypt
+  #   hosts:
+  #     - host: mimir.example.com
+  #       paths:
+  #         - path: /
+  #           pathType: Prefix
+  #   tls:
+  #     - hosts:
+  #         - mimir.example.com
+  #       secretName: mimir-example-com-tls
+
+# -- ServiceMonitor configuration
+serviceMonitor:
+  # -- Enable creation of a ServiceMonitor
+  enabled: false
+  # -- Namespace for the ServiceMonitor. Defaults to the release namespace when empty.
+  namespace: ""
+  # -- Labels added to the ServiceMonitor
+  labels: {}
+  # -- Annotations added to the ServiceMonitor
+  annotations: {}
+  # -- Scrape interval
+  interval: 30s
+  # -- Scrape timeout
+  scrapeTimeout: 10s
+  # -- Metrics path
+  path: /metrics
+  # -- Optional jobLabel
+  jobLabel: ""
+  # -- Extra matchLabels added to the ServiceMonitor selector
+  selector: {}
+  # -- Relabelings for the ServiceMonitor endpoint
+  relabelings: []
+  # -- Metric relabelings for the ServiceMonitor endpoint
+  metricRelabelings: []
+
+# -- Mimir configuration. This string is rendered with `tpl`, then merged with `mimir.structuredConfig`.
+mimir:
+  # -- Base Mimir config rendered into `mimir.yaml`. Prefer official config keys here.
+  config: |
+    target: all
+    multitenancy_enabled: false
+
+    common:
+      storage:
+        backend: s3
+        s3:
+          endpoint: s3.example.com
+          region: us-east-1
+          access_key_id: ${AWS_ACCESS_KEY_ID}
+          secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+          insecure: false
+
+    blocks_storage:
+      s3:
+        bucket_name: mimir-blocks
+      bucket_store:
+        sync_dir: /data/tsdb-sync
+      tsdb:
+        dir: /data/tsdb
+        head_compaction_interval: 15m
+        wal_replay_concurrency: 3
+
+    compactor:
+      data_dir: /data/compactor
+      sharding_ring:
+        kvstore:
+          store: memberlist
+
+    distributor:
+      ring:
+        kvstore:
+          store: memberlist
+
+    ingester:
+      ring:
+        replication_factor: {{ .Values.replicaCount }}
+        kvstore:
+          store: memberlist
+
+    store_gateway:
+      sharding_ring:
+        replication_factor: {{ .Values.replicaCount }}
+        kvstore:
+          store: memberlist
+
+    limits:
+      compactor_blocks_retention_period: 60d
+      max_global_series_per_user: 1000000
+      ingestion_rate: 50000
+      ingestion_burst_size: 1000000
+      out_of_order_time_window: 5m
+
+    memberlist:
+      bind_port: {{ .Values.memberlistService.port }}
+      abort_if_cluster_join_fails: false
+      join_members:
+        - dnssrv+{{ include "mimir.memberlistServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.memberlistService.port }}
+
+    server:
+      http_listen_port: {{ .Values.service.httpPort }}
+      grpc_listen_port: {{ .Values.service.grpcPort }}
+      log_level: info
+
+  # -- Structured overrides merged on top of `mimir.config`. Use this to add official config blocks such as `ruler_storage` or `alertmanager_storage` without copying the whole config.
+  structuredConfig: {}

--- a/flux/clusters/natsume/apps/mimir/helmrelease-mimir.yaml
+++ b/flux/clusters/natsume/apps/mimir/helmrelease-mimir.yaml
@@ -11,12 +11,11 @@ spec:
     createNamespace: false
   chart:
     spec:
-      chart: mimir
-      version: 0.1.6
+      chart: ./charts/mimir
       sourceRef:
-        kind: HelmRepository
-        name: mimir-repo
-        namespace: mimir
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
       interval: 1h
   values:
     envFrom:

--- a/flux/clusters/natsume/apps/mimir/helmrepository-mimir-repo.yaml
+++ b/flux/clusters/natsume/apps/mimir/helmrepository-mimir-repo.yaml
@@ -1,8 +1,0 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: mimir-repo
-  namespace: mimir
-spec:
-  interval: 1h
-  url: https://soli0222.github.io/helm-charts

--- a/flux/clusters/natsume/apps/mimir/kustomization.yaml
+++ b/flux/clusters/natsume/apps/mimir/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - namespace.yaml
-- helmrepository-mimir-repo.yaml
 - onepassworditem.yaml
 - helmrelease-mimir.yaml


### PR DESCRIPTION
Phase 2 の4件目 (#612, #614, #615 に続く)。

- `charts/mimir/` を helm-charts から移設 (published `mimir-0.1.6` と templates/values が完全一致することを確認済み)
- HelmRelease の chart source を `HelmRepository` → `GitRepository` に変更
- gh-pages を指す `HelmRepository` を削除し `kustomization.yaml` からも外す

**hr の diff が差分ゼロであることを確認してからマージする。**