### PR TITLE
feat(charts): move distribution chart into pke and switch to GitRepository

### DIFF
--- a/charts/distribution/Chart.yaml
+++ b/charts/distribution/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: distribution
+description: A Helm chart for Distribution Registry - A stateless, highly scalable container image registry
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.3
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+
+# renovate: image=docker.io/library/registry
+appVersion: "3.1.1"

--- a/charts/distribution/README.md
+++ b/charts/distribution/README.md
@@ -1,0 +1,130 @@
+# distribution
+
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+
+A Helm chart for Distribution Registry - A stateless, highly scalable container image registry
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity |
+| config | object | `{"auth":{},"enabled":true,"health":{"storagedriver":{"enabled":true,"interval":"10s","threshold":3}},"http":{"addr":":5000","debug":{"addr":":5001","prometheus":{"enabled":true,"path":"/metrics"}},"draintimeout":"60s","h2c":{"enabled":false},"headers":{"X-Content-Type-Options":["nosniff"]},"http2":{"disabled":false},"relativeurls":false,"secret":""},"log":{"accesslog":{"disabled":false},"formatter":"text","level":"info"},"notifications":{},"proxy":{},"redis":{},"storage":{"azure":{},"cache":{"blobdescriptor":"inmemory"},"delete":{"enabled":false},"filesystem":{"rootdirectory":"/var/lib/registry"},"gcs":{},"maintenance":{"uploadpurging":{"age":"168h","dryrun":false,"enabled":true,"interval":"24h"}},"redirect":{"disable":false},"s3":{}},"validation":{"disabled":false},"version":"0.1"}` | Registry configuration. See https://distribution.github.io/distribution/about/configuration/ |
+| config.auth | object | `{}` | Authentication configuration. Only one auth method can be configured at a time |
+| config.enabled | bool | `true` | Enable custom configuration (if false, uses default registry config) |
+| config.health | object | `{"storagedriver":{"enabled":true,"interval":"10s","threshold":3}}` | Health check configuration |
+| config.health.storagedriver | object | `{"enabled":true,"interval":"10s","threshold":3}` | Storage driver health check |
+| config.http | object | `{"addr":":5000","debug":{"addr":":5001","prometheus":{"enabled":true,"path":"/metrics"}},"draintimeout":"60s","h2c":{"enabled":false},"headers":{"X-Content-Type-Options":["nosniff"]},"http2":{"disabled":false},"relativeurls":false,"secret":""}` | HTTP server configuration |
+| config.http.addr | string | `":5000"` | HTTP listen address |
+| config.http.debug | object | `{"addr":":5001","prometheus":{"enabled":true,"path":"/metrics"}}` | Debug server configuration (exposes /debug/health and /metrics) |
+| config.http.debug.addr | string | `":5001"` | Debug server listen address |
+| config.http.debug.prometheus | object | `{"enabled":true,"path":"/metrics"}` | Prometheus metrics configuration |
+| config.http.debug.prometheus.enabled | bool | `true` | Enable Prometheus metrics |
+| config.http.debug.prometheus.path | string | `"/metrics"` | Metrics path |
+| config.http.draintimeout | string | `"60s"` | Time to wait for HTTP connections to drain on shutdown |
+| config.http.h2c | object | `{"enabled":false}` | H2C (HTTP/2 Cleartext) configuration |
+| config.http.h2c.enabled | bool | `false` | Enable H2C |
+| config.http.headers | object | `{"X-Content-Type-Options":["nosniff"]}` | HTTP response headers |
+| config.http.http2 | object | `{"disabled":false}` | HTTP/2 configuration |
+| config.http.http2.disabled | bool | `false` | Disable HTTP/2 |
+| config.http.relativeurls | bool | `false` | Return relative URLs in Location headers |
+| config.http.secret | string | `""` | HTTP secret for signing state. Auto-generated if not set |
+| config.log | object | `{"accesslog":{"disabled":false},"formatter":"text","level":"info"}` | Logging configuration |
+| config.log.accesslog | object | `{"disabled":false}` | Access log configuration |
+| config.log.accesslog.disabled | bool | `false` | Disable access logging |
+| config.log.formatter | string | `"text"` | Log formatter: text, json, logstash |
+| config.log.level | string | `"info"` | Log level: error, warn, info, debug |
+| config.notifications | object | `{}` | Notifications configuration for webhooks |
+| config.proxy | object | `{}` | Proxy configuration for pull-through cache. Credentials should be set in secrets.proxy |
+| config.redis | object | `{}` | Redis configuration for caching. Password should be set in secrets.redis |
+| config.storage | object | `{"azure":{},"cache":{"blobdescriptor":"inmemory"},"delete":{"enabled":false},"filesystem":{"rootdirectory":"/var/lib/registry"},"gcs":{},"maintenance":{"uploadpurging":{"age":"168h","dryrun":false,"enabled":true,"interval":"24h"}},"redirect":{"disable":false},"s3":{}}` | Only one storage backend should be configured at a time. S3/Azure/GCS takes priority over filesystem. |
+| config.storage.azure | object | `{}` | Azure Blob storage configuration. Credentials should be set in secrets.azure Ref: https://distribution.github.io/distribution/storage-drivers/azure/ |
+| config.storage.cache | object | `{"blobdescriptor":"inmemory"}` | Cache configuration for layer metadata |
+| config.storage.cache.blobdescriptor | string | `"inmemory"` | Cache type: inmemory or redis |
+| config.storage.delete | object | `{"enabled":false}` | Enable deletion of image blobs and manifests by digest |
+| config.storage.filesystem | object | enabled by default | Filesystem storage configuration (default backend) Ref: https://distribution.github.io/distribution/storage-drivers/filesystem/ |
+| config.storage.filesystem.rootdirectory | string | `"/var/lib/registry"` | Root directory for registry data (default: /var/lib/registry) |
+| config.storage.gcs | object | `{}` | Google Cloud Storage configuration. Credentials should be set in secrets.gcs Ref: https://distribution.github.io/distribution/storage-drivers/gcs/ |
+| config.storage.maintenance | object | `{"uploadpurging":{"age":"168h","dryrun":false,"enabled":true,"interval":"24h"}}` | Maintenance configuration |
+| config.storage.maintenance.uploadpurging | object | `{"age":"168h","dryrun":false,"enabled":true,"interval":"24h"}` | Upload purging configuration to remove orphaned files |
+| config.storage.redirect | object | `{"disable":false}` | Redirect configuration for storage backends that support it |
+| config.storage.redirect.disable | bool | `false` | Disable redirects to serve all data through the registry |
+| config.storage.s3 | object | `{}` | S3 storage configuration. Credentials should be set in secrets.s3 Ref: https://distribution.github.io/distribution/storage-drivers/s3/ |
+| config.validation | object | `{"disabled":false}` | Validation configuration |
+| config.validation.disabled | bool | `false` | Disable validation |
+| config.version | string | `"0.1"` | Configuration version (required) |
+| containerPort | int | `5000` | Container port for the registry |
+| debugPort | int | `5001` | Debug server port (for metrics and health checks) |
+| env | list | `[]` | Extra environment variables |
+| extraVolumeMounts | list | `[]` | Extra volume mounts |
+| extraVolumes | list | `[]` | Extra volumes |
+| fullnameOverride | string | `""` | Override the full name of the chart |
+| htpasswd | object | `{"credentials":"","enabled":false,"existingSecret":""}` | htpasswd authentication configuration |
+| htpasswd.credentials | string | `""` | htpasswd credentials in bcrypt format (username:bcrypt_hashed_password) |
+| htpasswd.enabled | bool | `false` | Enable htpasswd authentication |
+| htpasswd.existingSecret | string | `""` | Use existing secret containing htpasswd file |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"registry","tag":""}` | Image configuration |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"registry"` | Registry image repository |
+| image.tag | string | `""` | Registry image tag |
+| imagePullSecrets | list | `[]` | Image pull secrets |
+| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"registry.local","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[]}` | Ingress configuration |
+| ingress.annotations | object | `{}` | Ingress annotations |
+| ingress.className | string | `""` | Ingress class name |
+| ingress.enabled | bool | `false` | Enable ingress |
+| ingress.hosts | list | `[{"host":"registry.local","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress hosts |
+| ingress.tls | list | `[]` | Ingress TLS configuration |
+| livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/","port":"http"},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| nameOverride | string | `""` | Override the name of the chart |
+| nodeSelector | object | `{}` | Node selector |
+| otelTracesExporter | string | `"none"` | OpenTelemetry traces exporter. Set to "none" to disable traces, or specify your trace collector endpoint |
+| persistence | object | `{"accessModes":["ReadWriteOnce"],"enabled":true,"existingClaim":"","size":"10Gi","storageClass":""}` | Persistence configuration |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes |
+| persistence.enabled | bool | `true` | Enable persistence |
+| persistence.existingClaim | string | `""` | Use existing PVC (if specified, no new PVC will be created) |
+| persistence.size | string | `"10Gi"` | Storage size |
+| persistence.storageClass | string | `""` | Storage class for the PVC |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{}` | Pod security context |
+| readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/","port":"http"},"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe configuration |
+| replicaCount | int | `1` | Number of replicas |
+| resources | object | `{}` | Resource limits and requests |
+| secrets | object | `{"azure":{"accountKey":""},"existingSecret":"","gcs":{"keyfile":""},"proxy":{"password":"","username":""},"redis":{"password":""},"s3":{"accessKey":"","secretKey":""}}` | Secrets configuration for storage backends and other services. Values are stored in a Kubernetes Secret and injected as environment variables |
+| secrets.azure | object | `{"accountKey":""}` | Azure storage credentials |
+| secrets.azure.accountKey | string | `""` | Azure storage account key (injected as REGISTRY_STORAGE_AZURE_ACCOUNTKEY) |
+| secrets.existingSecret | string | `""` | Use existing secret for credentials. If set, other secret values are ignored. The existing secret should contain the following keys: s3-access-key, s3-secret-key, azure-account-key, gcs-keyfile, redis-password, proxy-username, proxy-password |
+| secrets.gcs | object | `{"keyfile":""}` | GCS storage credentials |
+| secrets.gcs.keyfile | string | `""` | GCS service account JSON key file content (mounted at /etc/distribution/gcs/keyfile.json) |
+| secrets.proxy | object | `{"password":"","username":""}` | Proxy credentials for pull-through cache with private upstream |
+| secrets.proxy.password | string | `""` | Proxy upstream password (injected as REGISTRY_PROXY_PASSWORD) |
+| secrets.proxy.username | string | `""` | Proxy upstream username (injected as REGISTRY_PROXY_USERNAME) |
+| secrets.redis | object | `{"password":""}` | Redis credentials |
+| secrets.redis.password | string | `""` | Redis password (injected as REGISTRY_REDIS_PASSWORD) |
+| secrets.s3 | object | `{"accessKey":"","secretKey":""}` | S3 storage credentials |
+| secrets.s3.accessKey | string | `""` | S3 access key (injected as REGISTRY_STORAGE_S3_ACCESSKEY) |
+| secrets.s3.secretKey | string | `""` | S3 secret key (injected as REGISTRY_STORAGE_S3_SECRETKEY) |
+| securityContext | object | `{}` | Container security context |
+| service | object | `{"port":5000,"targetPort":5000,"type":"ClusterIP"}` | Service configuration |
+| service.port | int | `5000` | Service port |
+| service.targetPort | int | `5000` | Target port |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount | object | `{"annotations":{},"create":false,"name":""}` | Service account configuration |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor | object | `{"annotations":{},"enabled":false,"interval":"30s","labels":{},"scrapeTimeout":"10s"}` | ServiceMonitor for Prometheus Operator |
+| serviceMonitor.annotations | object | `{}` | Annotations |
+| serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor |
+| serviceMonitor.interval | string | `"30s"` | Scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional labels |
+| serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout |
+| tls | object | `{"certificate":"","enabled":false,"existingSecret":"","key":""}` | TLS configuration |
+| tls.certificate | string | `""` | TLS certificate (if existingSecret is not set) |
+| tls.enabled | bool | `false` | Enable TLS |
+| tls.existingSecret | string | `""` | Use existing secret containing tls.crt and tls.key |
+| tls.key | string | `""` | TLS private key (if existingSecret is not set) |
+| tolerations | list | `[]` | Tolerations |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/distribution/templates/NOTES.txt
+++ b/charts/distribution/templates/NOTES.txt
@@ -1,0 +1,46 @@
+Distribution Registry has been deployed!
+
+{{- if .Values.ingress.enabled }}
+The registry is accessible at:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+Get the registry URL by running these commands:
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "distribution.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+Get the registry URL by running these commands:
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "distribution.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+Get the registry URL by running these commands:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "distribution.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:5000 to use your registry"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 5000:5000
+{{- end }}
+
+{{- if .Values.htpasswd.enabled }}
+
+Authentication is enabled. Use the configured credentials to push/pull images.
+{{- end }}
+
+{{- if .Values.serviceMonitor.enabled }}
+
+Prometheus ServiceMonitor is enabled. Metrics are available at:
+  http://{{ include "distribution.fullname" . }}:{{ .Values.debugPort }}{{ .Values.config.http.debug.prometheus.path | default "/metrics" }}
+{{- end }}
+
+Push an image to the registry:
+  docker tag myimage {{ if .Values.ingress.enabled }}{{ (index .Values.ingress.hosts 0).host }}{{ else }}localhost:5000{{ end }}/myimage
+  docker push {{ if .Values.ingress.enabled }}{{ (index .Values.ingress.hosts 0).host }}{{ else }}localhost:5000{{ end }}/myimage
+
+Pull an image from the registry:
+  docker pull {{ if .Values.ingress.enabled }}{{ (index .Values.ingress.hosts 0).host }}{{ else }}localhost:5000{{ end }}/myimage
+
+For more information, visit:
+  https://distribution.github.io/distribution/

--- a/charts/distribution/templates/_helpers.tpl
+++ b/charts/distribution/templates/_helpers.tpl
@@ -1,0 +1,131 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "distribution.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "distribution.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "distribution.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "distribution.labels" -}}
+helm.sh/chart: {{ include "distribution.chart" . }}
+{{ include "distribution.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "distribution.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "distribution.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "distribution.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "distribution.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+PVC name
+*/}}
+{{- define "distribution.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- printf "%s-data" (include "distribution.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+ConfigMap name
+*/}}
+{{- define "distribution.configMapName" -}}
+{{- printf "%s-config" (include "distribution.fullname" .) }}
+{{- end }}
+
+{{/*
+Secret name for HTTP secret
+*/}}
+{{- define "distribution.httpSecretName" -}}
+{{- printf "%s-http-secret" (include "distribution.fullname" .) }}
+{{- end }}
+
+{{/*
+Secret name for TLS
+*/}}
+{{- define "distribution.tlsSecretName" -}}
+{{- if .Values.tls.existingSecret }}
+{{- .Values.tls.existingSecret }}
+{{- else }}
+{{- printf "%s-tls" (include "distribution.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name for htpasswd
+*/}}
+{{- define "distribution.htpasswdSecretName" -}}
+{{- if .Values.htpasswd.existingSecret }}
+{{- .Values.htpasswd.existingSecret }}
+{{- else }}
+{{- printf "%s-htpasswd" (include "distribution.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name for credentials (S3, Azure, GCS, Redis, Proxy)
+*/}}
+{{- define "distribution.credentialsSecretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- printf "%s-credentials" (include "distribution.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate HTTP secret if not provided
+*/}}
+{{- define "distribution.httpSecret" -}}
+{{- if .Values.config.http.secret }}
+{{- .Values.config.http.secret }}
+{{- else }}
+{{- randAlphaNum 32 }}
+{{- end }}
+{{- end }}

--- a/charts/distribution/templates/configmap.yaml
+++ b/charts/distribution/templates/configmap.yaml
@@ -1,0 +1,192 @@
+{{- if .Values.config.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "distribution.configMapName" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+data:
+  config.yml: |
+    version: {{ .Values.config.version | quote }}
+    
+    log:
+      {{- if .Values.config.log.accesslog }}
+      accesslog:
+        disabled: {{ .Values.config.log.accesslog.disabled | default false }}
+      {{- end }}
+      level: {{ .Values.config.log.level | default "info" }}
+      formatter: {{ .Values.config.log.formatter | default "text" }}
+    
+    storage:
+      {{- /* Determine which storage backend to use. Only one should be active. */}}
+      {{- /* Priority: s3 > azure > gcs > filesystem */}}
+      {{- $useS3 := and .Values.config.storage.s3 (gt (len .Values.config.storage.s3) 0) }}
+      {{- $useAzure := and .Values.config.storage.azure (gt (len .Values.config.storage.azure) 0) }}
+      {{- $useGCS := and .Values.config.storage.gcs (gt (len .Values.config.storage.gcs) 0) }}
+      {{- $useFilesystem := and .Values.config.storage.filesystem (not $useS3) (not $useAzure) (not $useGCS) }}
+      {{- if $useFilesystem }}
+      filesystem:
+        rootdirectory: {{ .Values.config.storage.filesystem.rootdirectory | default "/var/lib/registry" }}
+        {{- if .Values.config.storage.filesystem.maxthreads }}
+        maxthreads: {{ .Values.config.storage.filesystem.maxthreads }}
+        {{- end }}
+      {{- end }}
+      {{- if $useS3 }}
+      s3:
+        {{- /* Remove accesskey and secretkey from config - they come from env vars */}}
+        {{- $s3Config := omit .Values.config.storage.s3 "accesskey" "secretkey" }}
+        {{- toYaml $s3Config | nindent 8 }}
+      {{- end }}
+      {{- if $useAzure }}
+      azure:
+        {{- /* Remove accountkey from config - it comes from env var */}}
+        {{- $azureConfig := omit .Values.config.storage.azure "accountkey" }}
+        {{- toYaml $azureConfig | nindent 8 }}
+      {{- end }}
+      {{- if $useGCS }}
+      gcs:
+        {{- /* Set keyfile path if credentials are provided via secret */}}
+        {{- if or .Values.secrets.gcs.keyfile .Values.secrets.existingSecret }}
+        keyfile: /etc/distribution/gcs/keyfile.json
+        {{- end }}
+        {{- $gcsConfig := omit .Values.config.storage.gcs "keyfile" "credentials" }}
+        {{- toYaml $gcsConfig | nindent 8 }}
+      {{- end }}
+      {{- if .Values.config.storage.delete }}
+      delete:
+        enabled: {{ .Values.config.storage.delete.enabled | default false }}
+      {{- end }}
+      {{- if .Values.config.storage.cache }}
+      cache:
+        blobdescriptor: {{ .Values.config.storage.cache.blobdescriptor | default "inmemory" }}
+        {{- if .Values.config.storage.cache.blobdescriptorsize }}
+        blobdescriptorsize: {{ .Values.config.storage.cache.blobdescriptorsize }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.config.storage.maintenance }}
+      maintenance:
+        {{- if .Values.config.storage.maintenance.uploadpurging }}
+        uploadpurging:
+          enabled: {{ .Values.config.storage.maintenance.uploadpurging.enabled | default true }}
+          age: {{ .Values.config.storage.maintenance.uploadpurging.age | default "168h" }}
+          interval: {{ .Values.config.storage.maintenance.uploadpurging.interval | default "24h" }}
+          dryrun: {{ .Values.config.storage.maintenance.uploadpurging.dryrun | default false }}
+        {{- end }}
+        {{- if .Values.config.storage.maintenance.readonly }}
+        readonly:
+          enabled: {{ .Values.config.storage.maintenance.readonly.enabled | default false }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.config.storage.redirect }}
+      redirect:
+        disable: {{ .Values.config.storage.redirect.disable | default false }}
+      {{- end }}
+      {{- if .Values.config.storage.tag }}
+      tag:
+        concurrencylimit: {{ .Values.config.storage.tag.concurrencylimit | default 8 }}
+      {{- end }}
+    
+    http:
+      addr: {{ .Values.config.http.addr | default ":5000" }}
+      {{- if .Values.config.http.prefix }}
+      prefix: {{ .Values.config.http.prefix }}
+      {{- end }}
+      {{- if .Values.config.http.host }}
+      host: {{ .Values.config.http.host }}
+      {{- end }}
+      relativeurls: {{ .Values.config.http.relativeurls | default false }}
+      {{- if .Values.config.http.draintimeout }}
+      draintimeout: {{ .Values.config.http.draintimeout }}
+      {{- end }}
+      {{- if .Values.config.http.headers }}
+      headers:
+        {{- range $key, $value := .Values.config.http.headers }}
+        {{ $key }}:
+          {{- toYaml $value | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.config.http.http2 }}
+      http2:
+        disabled: {{ .Values.config.http.http2.disabled | default false }}
+      {{- end }}
+      {{- if .Values.config.http.h2c }}
+      h2c:
+        enabled: {{ .Values.config.http.h2c.enabled | default false }}
+      {{- end }}
+      {{- if .Values.tls.enabled }}
+      tls:
+        certificate: /certs/tls.crt
+        key: /certs/tls.key
+      {{- end }}
+      {{- if .Values.config.http.debug }}
+      debug:
+        addr: {{ .Values.config.http.debug.addr | default ":5001" }}
+        {{- if .Values.config.http.debug.prometheus }}
+        prometheus:
+          enabled: {{ .Values.config.http.debug.prometheus.enabled | default true }}
+          path: {{ .Values.config.http.debug.prometheus.path | default "/metrics" }}
+        {{- end }}
+      {{- end }}
+    
+    {{- if .Values.htpasswd.enabled }}
+    auth:
+      htpasswd:
+        realm: Registry Realm
+        path: /auth/htpasswd
+    {{- else if .Values.config.auth }}
+    auth:
+      {{- toYaml .Values.config.auth | nindent 6 }}
+    {{- end }}
+    
+    {{- if .Values.config.health }}
+    health:
+      {{- if .Values.config.health.storagedriver }}
+      storagedriver:
+        enabled: {{ .Values.config.health.storagedriver.enabled | default true }}
+        {{- if .Values.config.health.storagedriver.interval }}
+        interval: {{ .Values.config.health.storagedriver.interval }}
+        {{- end }}
+        {{- if .Values.config.health.storagedriver.threshold }}
+        threshold: {{ .Values.config.health.storagedriver.threshold }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.config.health.file }}
+      file:
+        {{- toYaml .Values.config.health.file | nindent 8 }}
+      {{- end }}
+      {{- if .Values.config.health.http }}
+      http:
+        {{- toYaml .Values.config.health.http | nindent 8 }}
+      {{- end }}
+      {{- if .Values.config.health.tcp }}
+      tcp:
+        {{- toYaml .Values.config.health.tcp | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    
+    {{- if .Values.config.proxy }}
+    proxy:
+      {{- toYaml .Values.config.proxy | nindent 6 }}
+    {{- end }}
+    
+    {{- if .Values.config.validation }}
+    validation:
+      {{- if hasKey .Values.config.validation "disabled" }}
+      disabled: {{ .Values.config.validation.disabled }}
+      {{- end }}
+      {{- if .Values.config.validation.manifests }}
+      manifests:
+        {{- toYaml .Values.config.validation.manifests | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    
+    {{- if .Values.config.notifications }}
+    notifications:
+      {{- toYaml .Values.config.notifications | nindent 6 }}
+    {{- end }}
+    
+    {{- if .Values.config.redis }}
+    redis:
+      {{- toYaml .Values.config.redis | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/distribution/templates/deployment.yaml
+++ b/charts/distribution/templates/deployment.yaml
@@ -1,0 +1,197 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "distribution.fullname" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "distribution.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.config.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "distribution.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "distribution.serviceAccountName" . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+            {{- if .Values.config.http.debug }}
+            - name: debug
+              containerPort: {{ .Values.debugPort }}
+              protocol: TCP
+            {{- end }}
+          env:
+            - name: REGISTRY_HTTP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "distribution.httpSecretName" . }}
+                  key: http-secret
+            {{- if .Values.otelTracesExporter }}
+            - name: OTEL_TRACES_EXPORTER
+              value: {{ .Values.otelTracesExporter | quote }}
+            {{- end }}
+            {{- if .Values.htpasswd.enabled }}
+            - name: REGISTRY_AUTH_HTPASSWD_REALM
+              value: "Registry Realm"
+            - name: REGISTRY_AUTH_HTPASSWD_PATH
+              value: "/auth/htpasswd"
+            {{- end }}
+            {{- if or .Values.secrets.s3.accessKey .Values.secrets.existingSecret }}
+            - name: REGISTRY_STORAGE_S3_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "distribution.credentialsSecretName" . }}
+                  key: s3-access-key
+                  optional: true
+            - name: REGISTRY_STORAGE_S3_SECRETKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "distribution.credentialsSecretName" . }}
+                  key: s3-secret-key
+                  optional: true
+            {{- end }}
+            {{- if or .Values.secrets.azure.accountKey .Values.secrets.existingSecret }}
+            - name: REGISTRY_STORAGE_AZURE_ACCOUNTKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "distribution.credentialsSecretName" . }}
+                  key: azure-account-key
+                  optional: true
+            {{- end }}
+            {{- if or .Values.secrets.redis.password .Values.secrets.existingSecret }}
+            - name: REGISTRY_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "distribution.credentialsSecretName" . }}
+                  key: redis-password
+                  optional: true
+            {{- end }}
+            {{- if or .Values.secrets.proxy.username .Values.secrets.existingSecret }}
+            - name: REGISTRY_PROXY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "distribution.credentialsSecretName" . }}
+                  key: proxy-username
+                  optional: true
+            - name: REGISTRY_PROXY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "distribution.credentialsSecretName" . }}
+                  key: proxy-password
+                  optional: true
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /var/lib/registry
+            {{- end }}
+            {{- if .Values.config.enabled }}
+            - name: config
+              mountPath: /etc/distribution/config.yml
+              subPath: config.yml
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /certs
+              readOnly: true
+            {{- end }}
+            {{- if .Values.htpasswd.enabled }}
+            - name: htpasswd
+              mountPath: /auth
+              readOnly: true
+            {{- end }}
+            {{- $useGCS := and .Values.config.storage.gcs (gt (len .Values.config.storage.gcs) 0) }}
+            {{- if and $useGCS (or .Values.secrets.gcs.keyfile .Values.secrets.existingSecret) }}
+            - name: gcs-keyfile
+              mountPath: /etc/distribution/gcs
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "distribution.pvcName" . }}
+        {{- end }}
+        {{- if .Values.config.enabled }}
+        - name: config
+          configMap:
+            name: {{ include "distribution.configMapName" . }}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ include "distribution.tlsSecretName" . }}
+        {{- end }}
+        {{- if .Values.htpasswd.enabled }}
+        - name: htpasswd
+          secret:
+            secretName: {{ include "distribution.htpasswdSecretName" . }}
+        {{- end }}
+        {{- $useGCS := and .Values.config.storage.gcs (gt (len .Values.config.storage.gcs) 0) }}
+        {{- if and $useGCS (or .Values.secrets.gcs.keyfile .Values.secrets.existingSecret) }}
+        - name: gcs-keyfile
+          secret:
+            secretName: {{ include "distribution.credentialsSecretName" . }}
+            items:
+              - key: gcs-keyfile
+                path: keyfile.json
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/distribution/templates/ingress.yaml
+++ b/charts/distribution/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "distribution.fullname" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "distribution.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/distribution/templates/pvc.yaml
+++ b/charts/distribution/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "distribution.pvcName" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/distribution/templates/secret.yaml
+++ b/charts/distribution/templates/secret.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "distribution.httpSecretName" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+type: Opaque
+data:
+  http-secret: {{ include "distribution.httpSecret" . | b64enc | quote }}
+---
+{{- if and .Values.tls.enabled (not .Values.tls.existingSecret) }}
+{{- if and .Values.tls.certificate .Values.tls.key }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "distribution.tlsSecretName" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.tls.certificate | b64enc | quote }}
+  tls.key: {{ .Values.tls.key | b64enc | quote }}
+{{- end }}
+{{- end }}
+---
+{{- if and .Values.htpasswd.enabled (not .Values.htpasswd.existingSecret) }}
+{{- if .Values.htpasswd.credentials }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "distribution.htpasswdSecretName" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+type: Opaque
+data:
+  htpasswd: {{ .Values.htpasswd.credentials | b64enc | quote }}
+{{- end }}
+{{- end }}
+---
+{{- $hasCredentials := or .Values.secrets.s3.accessKey .Values.secrets.s3.secretKey .Values.secrets.azure.accountKey .Values.secrets.gcs.keyfile .Values.secrets.redis.password .Values.secrets.proxy.username .Values.secrets.proxy.password }}
+{{- if and $hasCredentials (not .Values.secrets.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "distribution.credentialsSecretName" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.secrets.s3.accessKey }}
+  s3-access-key: {{ .Values.secrets.s3.accessKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.s3.secretKey }}
+  s3-secret-key: {{ .Values.secrets.s3.secretKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.azure.accountKey }}
+  azure-account-key: {{ .Values.secrets.azure.accountKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.gcs.keyfile }}
+  gcs-keyfile: {{ .Values.secrets.gcs.keyfile | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.redis.password }}
+  redis-password: {{ .Values.secrets.redis.password | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.proxy.username }}
+  proxy-username: {{ .Values.secrets.proxy.username | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.proxy.password }}
+  proxy-password: {{ .Values.secrets.proxy.password | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/distribution/templates/service.yaml
+++ b/charts/distribution/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "distribution.fullname" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if .Values.config.http.debug }}
+    - port: {{ .Values.debugPort }}
+      targetPort: debug
+      protocol: TCP
+      name: debug
+    {{- end }}
+  selector:
+    {{- include "distribution.selectorLabels" . | nindent 4 }}

--- a/charts/distribution/templates/serviceaccount.yaml
+++ b/charts/distribution/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "distribution.serviceAccountName" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/distribution/templates/servicemonitor.yaml
+++ b/charts/distribution/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "distribution.fullname" . }}
+  labels:
+    {{- include "distribution.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "distribution.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: debug
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      path: {{ .Values.config.http.debug.prometheus.path | default "/metrics" }}
+{{- end }}

--- a/charts/distribution/values.yaml
+++ b/charts/distribution/values.yaml
@@ -1,0 +1,396 @@
+# Default values for distribution.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Override the name of the chart
+nameOverride: ""
+# -- Override the full name of the chart
+fullnameOverride: ""
+
+# -- Image configuration
+image:
+  # -- Registry image repository
+  repository: registry
+  # -- Registry image tag
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets
+imagePullSecrets: []
+
+# -- Service account configuration
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: false
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- Pod security context
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Container security context
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# -- Number of replicas
+replicaCount: 1
+
+# -- Service configuration
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 5000
+  # -- Target port
+  targetPort: 5000
+
+# -- Container port for the registry
+containerPort: 5000
+
+# -- Debug server port (for metrics and health checks)
+debugPort: 5001
+
+# -- Resource limits and requests
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Affinity
+affinity: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Persistence configuration
+persistence:
+  # -- Enable persistence
+  enabled: true
+  # -- Use existing PVC (if specified, no new PVC will be created)
+  existingClaim: ""
+  # -- Storage class for the PVC
+  storageClass: ""
+  # -- Storage size
+  size: 10Gi
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+
+# -- Ingress configuration
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name
+  className: ""
+  # -- Ingress annotations
+  annotations: {}
+  # -- Ingress hosts
+  hosts:
+    - host: registry.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+
+# -- Registry configuration. See https://distribution.github.io/distribution/about/configuration/
+config:
+  # -- Enable custom configuration (if false, uses default registry config)
+  enabled: true
+  
+  # -- Configuration version (required)
+  version: "0.1"
+  
+  # -- Logging configuration
+  log:
+    # -- Log level: error, warn, info, debug
+    level: info
+    # -- Log formatter: text, json, logstash
+    formatter: text
+    # -- Access log configuration
+    accesslog:
+      # -- Disable access logging
+      disabled: false
+  
+  # -- HTTP server configuration
+  http:
+    # -- HTTP listen address
+    addr: :5000
+    # -- HTTP secret for signing state. Auto-generated if not set
+    secret: ""
+    # -- Return relative URLs in Location headers
+    relativeurls: false
+    # -- Time to wait for HTTP connections to drain on shutdown
+    draintimeout: 60s
+    # -- HTTP response headers
+    headers:
+      X-Content-Type-Options:
+        - nosniff
+    # -- HTTP/2 configuration
+    http2:
+      # -- Disable HTTP/2
+      disabled: false
+    # -- H2C (HTTP/2 Cleartext) configuration
+    h2c:
+      # -- Enable H2C
+      enabled: false
+    # -- Debug server configuration (exposes /debug/health and /metrics)
+    debug:
+      # -- Debug server listen address
+      addr: :5001
+      # -- Prometheus metrics configuration
+      prometheus:
+        # -- Enable Prometheus metrics
+        enabled: true
+        # -- Metrics path
+        path: /metrics
+  
+  # Storage configuration
+  # Storage configuration
+  # -- Only one storage backend should be configured at a time. S3/Azure/GCS takes priority over filesystem.
+  storage:
+    # -- Filesystem storage configuration (default backend)
+    # @default -- enabled by default
+    # Ref: https://distribution.github.io/distribution/storage-drivers/filesystem/
+    filesystem:
+      # -- Root directory for registry data (default: /var/lib/registry)
+      rootdirectory: /var/lib/registry
+      # -- Maximum number of simultaneous file operations (default: 100, min: 25)
+      # maxthreads: 100
+    
+    # -- S3 storage configuration. Credentials should be set in secrets.s3
+    # Ref: https://distribution.github.io/distribution/storage-drivers/s3/
+    s3: {}
+      # region: us-east-1  # (required) AWS region
+      # bucket: my-registry-bucket  # (required) S3 bucket name
+      # regionendpoint: http://myobjects.local  # (optional) S3-compatible endpoint
+      # forcepathstyle: false  # (optional, default: false)
+      # encrypt: false  # (optional, default: false)
+      # keyid: ""  # (optional) KMS key ID for encryption
+      # secure: true  # (optional, default: true)
+      # skipverify: false  # (optional, default: false)
+      # v4auth: true  # (optional, default: true)
+      # chunksize: 10485760  # (optional, default: 10MB, min: 5MB)
+      # multipartcopychunksize: 33554432  # (optional, default: 32MB)
+      # multipartcopymaxconcurrency: 100  # (optional, default: 100)
+      # multipartcopythresholdsize: 33554432  # (optional, default: 32MB)
+      # rootdirectory: ""  # (optional, default: bucket root)
+      # storageclass: STANDARD  # (optional, default: STANDARD)
+      # objectacl: private  # (optional, default: private)
+      # loglevel: "off"  # (optional, default: off)
+    
+    # -- Azure Blob storage configuration. Credentials should be set in secrets.azure
+    # Ref: https://distribution.github.io/distribution/storage-drivers/azure/
+    azure: {}
+      # accountname: myaccount  # (required)
+      # container: mycontainer  # (required)
+      # credentials:  # (required)
+      #   type: client_secret  # client_secret, shared_key, or default_credentials
+      #   clientid: ""  # required for client_secret
+      #   tenantid: ""  # required for client_secret
+      #   secret: ""  # required for client_secret
+      # rootdirectory: ""  # (optional)
+      # realm: core.windows.net  # (optional, default: core.windows.net)
+    
+    # -- Google Cloud Storage configuration. Credentials should be set in secrets.gcs
+    # Ref: https://distribution.github.io/distribution/storage-drivers/gcs/
+    gcs: {}
+      # bucket: my-gcs-bucket  # (required)
+      # rootdirectory: ""  # (optional, default: bucket root)
+      # chunksize: 5242880  # (optional, default: 5MB, must be multiple of 256KB)
+    
+    # -- Enable deletion of image blobs and manifests by digest
+    delete:
+      enabled: false
+    # -- Cache configuration for layer metadata
+    cache:
+      # -- Cache type: inmemory or redis
+      blobdescriptor: inmemory
+      # -- Maximum number of entries in inmemory cache
+      # blobdescriptorsize: 10000
+    # -- Maintenance configuration
+    maintenance:
+      # -- Upload purging configuration to remove orphaned files
+      uploadpurging:
+        enabled: true
+        age: 168h
+        interval: 24h
+        dryrun: false
+    # -- Redirect configuration for storage backends that support it
+    redirect:
+      # -- Disable redirects to serve all data through the registry
+      disable: false
+    # -- Tag lookup concurrency limit
+    # tag:
+      # -- Maximum concurrent tag lookups (0 = GOMAXPROCS)
+      # concurrencylimit: 8
+
+  # -- Authentication configuration. Only one auth method can be configured at a time
+  auth: {}
+    # htpasswd:
+    #   realm: Registry Realm
+    #   path: /auth/htpasswd
+    # token:
+    #   realm: https://auth.example.com/token
+    #   service: registry
+    #   issuer: registry-token-issuer
+    #   rootcertbundle: /certs/token.pem
+
+  # -- Health check configuration
+  health:
+    # -- Storage driver health check
+    storagedriver:
+      enabled: true
+      interval: 10s
+      threshold: 3
+
+  # -- Proxy configuration for pull-through cache. Credentials should be set in secrets.proxy
+  proxy: {}
+    # remoteurl: https://registry-1.docker.io
+    # ttl: 168h
+
+  # -- Validation configuration
+  validation:
+    # -- Disable validation
+    disabled: false
+
+  # -- Notifications configuration for webhooks
+  notifications: {}
+    # events:
+    #   includereferences: true
+    # endpoints:
+    #   - name: webhook
+    #     disabled: false
+    #     url: https://webhook.example.com/event
+    #     timeout: 1s
+    #     threshold: 10
+    #     backoff: 1s
+
+  # -- Redis configuration for caching. Password should be set in secrets.redis
+  redis: {}
+    # addrs:
+    #   - localhost:6379
+    # db: 0
+    # dialtimeout: 10ms
+    # readtimeout: 10ms
+    # writetimeout: 10ms
+
+# -- Secrets configuration for storage backends and other services. Values are stored in a Kubernetes Secret and injected as environment variables
+secrets:
+  # -- Use existing secret for credentials. If set, other secret values are ignored. The existing secret should contain the following keys: s3-access-key, s3-secret-key, azure-account-key, gcs-keyfile, redis-password, proxy-username, proxy-password
+  existingSecret: ""
+  
+  # -- S3 storage credentials
+  s3:
+    # -- S3 access key (injected as REGISTRY_STORAGE_S3_ACCESSKEY)
+    accessKey: ""
+    # -- S3 secret key (injected as REGISTRY_STORAGE_S3_SECRETKEY)
+    secretKey: ""
+  
+  # -- Azure storage credentials
+  azure:
+    # -- Azure storage account key (injected as REGISTRY_STORAGE_AZURE_ACCOUNTKEY)
+    accountKey: ""
+  
+  # -- GCS storage credentials
+  gcs:
+    # -- GCS service account JSON key file content (mounted at /etc/distribution/gcs/keyfile.json)
+    keyfile: ""
+  
+  # -- Redis credentials
+  redis:
+    # -- Redis password (injected as REGISTRY_REDIS_PASSWORD)
+    password: ""
+  
+  # -- Proxy credentials for pull-through cache with private upstream
+  proxy:
+    # -- Proxy upstream username (injected as REGISTRY_PROXY_USERNAME)
+    username: ""
+    # -- Proxy upstream password (injected as REGISTRY_PROXY_PASSWORD)
+    password: ""
+
+# -- TLS configuration
+tls:
+  # -- Enable TLS
+  enabled: false
+  # -- Use existing secret containing tls.crt and tls.key
+  existingSecret: ""
+  # -- TLS certificate (if existingSecret is not set)
+  certificate: ""
+  # -- TLS private key (if existingSecret is not set)
+  key: ""
+
+# -- htpasswd authentication configuration
+htpasswd:
+  # -- Enable htpasswd authentication
+  enabled: false
+  # -- Use existing secret containing htpasswd file
+  existingSecret: ""
+  # -- htpasswd credentials in bcrypt format (username:bcrypt_hashed_password)
+  credentials: ""
+
+# -- ServiceMonitor for Prometheus Operator
+serviceMonitor:
+  # -- Enable ServiceMonitor
+  enabled: false
+  # -- Scrape interval
+  interval: 30s
+  # -- Scrape timeout
+  scrapeTimeout: 10s
+  # -- Additional labels
+  labels: {}
+  # -- Annotations
+  annotations: {}
+
+# -- Liveness probe configuration
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- OpenTelemetry traces exporter. Set to "none" to disable traces, or specify your trace collector endpoint
+otelTracesExporter: "none"
+
+# -- Extra environment variables
+env: []
+
+# -- Extra volume mounts
+extraVolumeMounts: []
+
+# -- Extra volumes
+extraVolumes: []

--- a/flux/clusters/natsume/apps/registry/helmrelease-distribution.yaml
+++ b/flux/clusters/natsume/apps/registry/helmrelease-distribution.yaml
@@ -14,12 +14,11 @@ spec:
     crds: CreateReplace
   chart:
     spec:
-      chart: distribution
-      version: 0.1.3
+      chart: ./charts/distribution
       sourceRef:
-        kind: HelmRepository
-        name: distribution-repo
-        namespace: registry
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
       interval: 1h
   values:
     resources:

--- a/flux/clusters/natsume/apps/registry/helmrepository-distribution-repo.yaml
+++ b/flux/clusters/natsume/apps/registry/helmrepository-distribution-repo.yaml
@@ -1,8 +1,0 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: distribution-repo
-  namespace: registry
-spec:
-  interval: 1h
-  url: https://soli0222.github.io/helm-charts

--- a/flux/clusters/natsume/apps/registry/kustomization.yaml
+++ b/flux/clusters/natsume/apps/registry/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - namespace.yaml
-- helmrepository-distribution-repo.yaml
 - helmrelease-distribution.yaml
 - helmrepository-valkey-repo-2.yaml
 - helmrelease-registry-valkey.yaml


### PR DESCRIPTION
Phase 2 の6件目 (#612, #614, #615, #616, #617 に続く)。

- `charts/distribution/` を helm-charts から移設 (published `distribution-0.1.3` と templates/values が完全一致することを確認済み)
- HelmRelease の chart source を `HelmRepository` → `GitRepository` に変更
- gh-pages を指す `HelmRepository` を削除し `kustomization.yaml` からも外す

private registry (`registry.str08.net`) の実体なので **hr の diff が差分ゼロであることを確認してからマージする。**