### PR TITLE
chore(charts): port renovate rules from helm-charts and document the charts/ convention

### DIFF
--- a/.github/workflows/chart-version-guard.yaml
+++ b/.github/workflows/chart-version-guard.yaml
@@ -1,0 +1,70 @@
+name: chart-version-guard
+
+# pke 本体の charts/ を変更したら Chart.yaml の version を必ず上げさせる。
+#
+# HelmChart.spec.reconcileStrategy の既定は ChartVersion なので、GitRepository を
+# 参照していても version が上がらない限り新しい chart artifact は作られない。
+# version を据え置いたまま chart を変更すると flux-diff には差分が出るのに
+# 実際には reconcile されない、という一番たちの悪い状態になる。
+
+on:
+  pull_request:
+    paths:
+      - "charts/**"
+      - ".github/workflows/chart-version-guard.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Require a version bump for every changed chart
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          base=$(git merge-base "${BASE_SHA}" HEAD)
+
+          # 変更のあった chart ディレクトリ。README.md だけの変更は chart artifact に
+          # 影響しないので対象外にする。
+          mapfile -t charts < <(
+            git diff --name-only "${base}" HEAD -- charts \
+              | grep -v '^charts/[^/]*/README\.md$' \
+              | cut -d/ -f1,2 \
+              | sort -u
+          )
+
+          if [[ ${#charts[@]} -eq 0 ]]; then
+            echo "version に影響する chart の変更はありません。"
+            exit 0
+          fi
+
+          failed=0
+          for chart in "${charts[@]}"; do
+            head_version=$(yq -r '.version' "${chart}/Chart.yaml")
+
+            if ! base_version=$(git show "${base}:${chart}/Chart.yaml" 2>/dev/null | yq -r '.version'); then
+              echo "  ${chart}: 新規追加 (${head_version})"
+              continue
+            fi
+
+            if [[ "$base_version" == "$head_version" ]]; then
+              echo "::error file=${chart}/Chart.yaml::${chart} を変更したのに version が ${base_version} のままです。Flux は Chart.yaml の version が上がらない限り新しい chart artifact を作らないので、この変更は反映されません。"
+              failed=1
+            elif [[ "$(printf '%s\n%s\n' "$base_version" "$head_version" | sort -V | tail -1)" != "$head_version" ]]; then
+              echo "::error file=${chart}/Chart.yaml::${chart} の version が ${base_version} から ${head_version} へ下がっています。"
+              failed=1
+            else
+              echo "  ${chart}: ${base_version} -> ${head_version}"
+            fi
+          done
+
+          exit "$failed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,15 +133,31 @@ root `kustomization.yaml` への登録を忘れない。
 HelmRelease の chart version は Renovate が追跡できる形で明示する。
 Secret は 1Password Operator の `OnePasswordItem` を基本にし、平文 Secret をコミットしない。
 
-自作アプリのうち release-please を導入したアプリ(daypassed-bot, emoji-renderer,
-emoji-bot-gateway, mk-stream, note-tweet-connector, rss-fetcher, spotify-nowplaying,
-spotify-reblend)は chart を各アプリ自身のリポジトリの `charts/` に持ち、リリース時に
-`oci://ghcr.io/soli0222/charts` へ publish する。これらの HelmRepository は
-`spec.type: oci` を持ち、`spec.url: oci://ghcr.io/soli0222/charts` を指す。
-chart version はアプリの release タグと一致する。
-それ以外(第三者イメージの chart や release-please 未導入のアプリ)は引き続き
-`Soli0222/helm-charts` モノレポが GitHub Pages (`https://soli0222.github.io/helm-charts`)
-で配布する。
+Helm chart の出どころは 3 通り。
+
+| chart | source | 参照の仕方 |
+|-------|--------|------------|
+| 第三者の chart | 各 upstream の `HelmRepository` | chart version を pin |
+| 自作アプリ(release-please 導入済み) | `oci://ghcr.io/soli0222/charts` | `spec.type: oci` の `HelmRepository` |
+| 第三者イメージのラッパー | **この pke リポジトリの `charts/`** | `GitRepository` (flux-system) を `chart: ./charts/<name>` で参照 |
+
+自作アプリ(daypassed-bot, emoji-renderer, emoji-bot-gateway, mk-stream,
+note-tweet-connector, rss-fetcher, spotify-nowplaying, spotify-reblend)は chart を
+各アプリ自身のリポジトリの `charts/` に持ち、`oci://ghcr.io/soli0222/charts` へ
+publish する。chart の `version` と `appVersion` は別物で、`version` は chart 自体の
+変更に対して上がり、`appVersion` がアプリの release タグを指す。
+
+第三者イメージのラッパー chart(blackbox-exporter-probes, distribution,
+mc-mirror-cronjob, mimir, misskey, navidrome, summaly)は pke 本体の `charts/` に置き、
+Flux の `GitRepository` から直接参照する。pke 自身が唯一の消費者なので、OCI へ
+publish して pull し直す往復は挟まない。
+
+`charts/` の chart でも `Chart.yaml` の `version` は残し、変更時に必ず上げる。
+`HelmChart.spec.reconcileStrategy` の既定は `ChartVersion` で、GitRepository を
+参照していても **`version` が上がらない限り新しい chart artifact は作られない**ため
+(`reconcileStrategy: Revision` にすると GitRepository を共有している全 chart が
+commit のたびに新 revision 扱いになるので採らない)。image tag の更新に対する
+patch bump は Renovate の `bumpVersions` が行う。
 
 ### natsume Components
 

--- a/README.md
+++ b/README.md
@@ -182,14 +182,31 @@ Flux の root は `flux/clusters/<cluster>/kustomization.yaml` です。
 `cert-manager-config` は `letsencrypt-dns01`、`letsencrypt-http01`、Traefik mTLS 用の `pke-natsume-mtls` `TLSOption` を持ちます。
 `cnpg-backup-config` は Flux の postBuild substitution 用 Secret `cnpg-backup-flux-vars` を 1Password から作ります。
 
-自作アプリのうち release-please を導入したアプリ(daypassed-bot, emoji-renderer,
-emoji-bot-gateway, mk-stream, note-tweet-connector, rss-fetcher, spotify-nowplaying,
-spotify-reblend)は Helm chart を各アプリ自身のリポジトリの `charts/` に持ち、リリース時に
-`oci://ghcr.io/soli0222/charts` へ publish します。対応する `HelmRepository` は
-`spec.type: oci` / `spec.url: oci://ghcr.io/soli0222/charts` を指し、chart version は
-アプリの release タグと一致します。それ以外(第三者イメージの chart や
-release-please 未導入のアプリ)は引き続き `Soli0222/helm-charts` モノレポが
-GitHub Pages (`https://soli0222.github.io/helm-charts`) で配布します。
+Helm chart の出どころは 3 通りあります。
+
+| chart | source | 参照の仕方 |
+|-------|--------|------------|
+| 第三者の chart | 各 upstream の `HelmRepository` | chart version を pin |
+| 自作アプリ(release-please 導入済み) | `oci://ghcr.io/soli0222/charts` | `spec.type: oci` の `HelmRepository` |
+| 第三者イメージのラッパー | **この pke リポジトリの `charts/`** | `GitRepository` (flux-system) を `chart: ./charts/<name>` で参照 |
+
+自作アプリ(daypassed-bot, emoji-renderer, emoji-bot-gateway, mk-stream,
+note-tweet-connector, rss-fetcher, spotify-nowplaying, spotify-reblend)は chart を
+各アプリ自身のリポジトリの `charts/` に持ち、`oci://ghcr.io/soli0222/charts` へ
+publish します。chart の `version` と `appVersion` は別物です。`version` は chart
+自体の変更に対して上がり、`appVersion` がアプリの release タグを指します。
+
+第三者イメージのラッパー chart(blackbox-exporter-probes, distribution,
+mc-mirror-cronjob, mimir, misskey, navidrome, summaly)は pke 本体の `charts/` に
+置き、Flux の `GitRepository` から直接参照します。pke 自身が唯一の消費者なので、
+OCI へ publish して pull し直す往復は挟みません。
+
+`charts/` の chart でも `Chart.yaml` の `version` は残し、変更時に必ず上げます。
+`HelmChart.spec.reconcileStrategy` の既定は `ChartVersion` で、GitRepository を
+参照していても **`version` が上がらない限り新しい chart artifact は作られない**
+ためです(`reconcileStrategy: Revision` にすると GitRepository を共有している
+全 chart が commit のたびに新 revision 扱いになるので採りません)。image tag の
+更新に対する patch bump は Renovate の `bumpVersions` が行います。
 
 ### meruto
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -36,6 +36,12 @@
   kubernetes: {
     managerFilePatterns: [
       '/(^|/)flux/.+/cronjob-.+\\.ya?ml$/',
+      '/(^|/)charts/.+/values\\.yaml$/',
+    ],
+  },
+  'helm-values': {
+    managerFilePatterns: [
+      '/(^|/)charts/.+/values\\.yaml$/',
     ],
   },
   packageRules: [
@@ -113,8 +119,65 @@
         'manager:ansible-vars',
       ],
     },
+    // charts/ の第三者イメージ追従。helm-charts から移植。automerge はしない。
+    {
+      matchFileNames: [
+        'charts/**',
+      ],
+      matchDatasources: [
+        'docker',
+      ],
+      commitMessagePrefix: 'chore(chart):',
+      addLabels: [
+        'manager:charts',
+      ],
+      automerge: false,
+    },
+  ],
+  // charts/ の image tag を上げたら同じ PR で chart version の patch を上げる。
+  // GitRepository 参照でも HelmChart.spec.reconcileStrategy の既定は ChartVersion
+  // なので、version が上がらないと新しい chart artifact が作られず反映されない。
+  //
+  // filePatterns は更新対象ファイルのディレクトリ基準なので、Chart.yaml を持たない
+  // flux/ 以下の更新には一致せず影響しない。
+  bumpVersions: [
+    {
+      filePatterns: [
+        '{{packageFileDir}}/Chart.yaml',
+      ],
+      matchStrings: [
+        '(?:^|\\n)version:\\s*(?<version>[^\\s]+)',
+      ],
+      bumpType: 'patch',
+    },
   ],
   customManagers: [
+    // charts/*/values.yaml の `repository:` + `tag:` の組。helm-values だけでは
+    // 拾えない書き方を補う。helm-charts から移植。
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/(^|/)charts/.+/values\\.yaml$/',
+      ],
+      matchStrings: [
+        'repository:\\s*(?<depName>[^\\s]+)\\s+tag:\\s*["\'](?<currentValue>[^"\']+)["\']',
+      ],
+      datasourceTemplate: 'docker',
+      versioningTemplate: 'docker',
+    },
+    // charts/*/Chart.yaml の appVersion を `# renovate: image=...` で追従させる。
+    // helm-charts から移植。
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/(^|/)charts/.+/Chart\\.yaml$/',
+      ],
+      matchStrings: [
+        '#\\s*renovate:\\s*image=(?<depName>[^\\s]+)\\nappVersion:\\s*["\']?(?<currentValue>[^"\'\\s]+)["\']?',
+      ],
+      datasourceTemplate: 'docker',
+      versioningTemplate: 'docker',
+    },
     {
       customType: 'regex',
       managerFilePatterns: [


### PR DESCRIPTION
Phase 2 の仕上げ。chart 移設 (#612, #614, #615, #616, #617, #618, #619) の残り。

## renovate

helm-charts の設定を pke へ移植する。

- `charts/*/values.yaml` を `helm-values` / `kubernetes` / `custom.regex` の対象に追加
- `Chart.yaml` の `# renovate: image=` コメントによる `appVersion` 追従
- image tag 更新時に同じ PR で chart version の patch を上げる (`bumpVersions`)
- `charts/**` の第三者イメージ更新は `chore(chart):` prefix、**automerge しない**

`bumpVersions` の `filePatterns` は更新対象ファイルのディレクトリ基準なので、`Chart.yaml` を持たない `flux/` 以下の更新には一致せず影響しない。

## chart-version-guard (新規)

`charts/` を変更したら `Chart.yaml` の `version` を必ず上げさせる required check。

`HelmChart.spec.reconcileStrategy` の既定は `ChartVersion` なので、GitRepository を参照していても **version が上がらない限り新しい chart artifact は作られない**。version を据え置いたまま chart を変更すると、**flux-diff には差分が出るのに実際には reconcile されない**という一番たちの悪い状態になる。それを PR の時点で止める。

`README.md` だけの変更は chart artifact に影響しないので対象外。

## ドキュメント

chart の出どころが 3 通りになったので表で書き直す。

| chart | source | 参照の仕方 |
|-------|--------|------------|
| 第三者の chart | 各 upstream の `HelmRepository` | chart version を pin |
| 自作アプリ | `oci://ghcr.io/soli0222/charts` | `spec.type: oci` の `HelmRepository` |
| 第三者イメージのラッパー | pke 本体の `charts/` | `GitRepository` を `chart: ./charts/<name>` で参照 |

「chart version はアプリの release タグと一致する」という記述は version と appVersion を分離した時点で古くなっていたので直す。