### PR TITLE
chore(terraform): manage the shared-workflows repository

### DIFF
--- a/terraform/github/repositories.yaml
+++ b/terraform/github/repositories.yaml
@@ -86,6 +86,9 @@ repositories:
 
   rss-fetcher: {}
 
+  shared-workflows:
+    description: Reusable GitHub Actions workflows shared across application repositories
+
   spotify-nowplaying:
     description: Web App for Easily Sharing Currently Playing Songs on Spotify
     homepage_url: https://spn.soli0222.com


### PR DESCRIPTION
自作アプリ9リポジトリのリリースパイプラインの実体を置く https://github.com/Soli0222/shared-workflows を terraform の管理下に入れる。

## apply 前に import が必要

リポジトリ自体は `gh repo create` で先に作ってあるので、そのままだと `terraform apply` が作成しようとして 422 になる。

```console
$ cd terraform/github
$ terraform import 'github_repository.repositories["shared-workflows"]' shared-workflows
```

import 後の `terraform plan` で global 既定 (topics: [renovate] や secret scanning、`RENOVATE_CLIENT_ID` / `RENOVATE_PRIVATE_KEY`) との差分が出るはずなので、それを apply すれば他リポジトリと同じ設定に揃う。

## 補足

shared-workflows 側には renovate の workflow と `renovate.json5` を入れてある (`actions/checkout` や `azure/setup-helm` を pin して使っているため)。上の secrets 配布はその前提。action の更新は影響範囲が広いので automerge しない設定にしている。