### PR TITLE
feat(flux): switch the sui chart source to OCI

### DIFF
--- a/flux/clusters/natsume/apps/sui/helmrepository-sui-repo.yaml
+++ b/flux/clusters/natsume/apps/sui/helmrepository-sui-repo.yaml
@@ -4,5 +4,6 @@ metadata:
   name: sui-repo
   namespace: sui
 spec:
+  type: oci
   interval: 1h
-  url: https://soli0222.github.io/helm-charts
+  url: oci://ghcr.io/soli0222/charts


### PR DESCRIPTION
sui の chart は Soli0222/sui#471 で `Soli0222/sui` の `charts/sui/` へ移設され、`oci://ghcr.io/soli0222/charts` へ publish されるようになった。

```console
$ helm show chart oci://ghcr.io/soli0222/charts/sui --version 0.3.0
name: sui
version: 0.3.0
appVersion: 2.0.0-beta.3
```

chart version は `0.3.0` のまま系列を引き継いでいるので、HelmRelease の `version` は変えない。**これで helm-charts の gh-pages を参照する HelmRepository は pke から無くなる** (Phase 4 の前提)。

`helmrelease-sui.yaml` は現在 `values.image.tag: 2.0.0-beta.4` を直接指定しているベータ検証中の意図的な特例で、この間 `appVersion` は実際の配備に影響しない。特例は維持する。

**hr の diff が差分ゼロであることを確認してからマージする。**

## GHCR の tag list 伝播遅延に注意

push 直後は manifest 直接取得は成功するのに tags/list API への反映にラグが出ることがある。Flux は一度 chart 解決に失敗すると HelmChart が Stalled になり自動再試行しないので、その場合は手動で reconcile する。

```console
$ flux reconcile source chart sui
```

(`kubectl get helmchart` は Rancher の CRD と名前が衝突するので `helmcharts.source.toolkit.fluxcd.io` を明示する)