### PR TITLE
chore(terraform): archive the helm-charts repository

### DIFF
--- a/terraform/github/repositories.yaml
+++ b/terraform/github/repositories.yaml
@@ -48,7 +48,11 @@ repositories:
 
   emoji-renderer: {}
 
-  helm-charts: {}
+  helm-charts:
+    archived: true
+    description: >-
+      Retired. Charts moved to the application repositories
+      (oci://ghcr.io/soli0222/charts) and to pke/charts/.
 
   mk-stream:
     security_and_analysis:


### PR DESCRIPTION
helm-charts 廃止 (Phase 4) の最後。

chart はすべて移設済み。

| chart | 移設先 |
|-------|--------|
| 自作アプリ8つ | 各アプリのリポジトリの `charts/` → `oci://ghcr.io/soli0222/charts` |
| `sui` | Soli0222/sui の `charts/sui/` → `oci://ghcr.io/soli0222/charts` |
| 第三者イメージのラッパー7つ | この pke の `charts/` (Flux が GitRepository で直接参照) |
| `mermaid-live-editor` | どこからも参照されていなかったため移設せず廃止 |

`grep -rn 'soli0222.github.io/helm-charts'` を `~/work` 配下の全リポジトリに対して走査し、helm-charts 自身の README / docs 以外 **0 件**であることを確認済み。README には移設先の対応表を置いた (Soli0222/helm-charts#159)。

`terraform apply` で `archived: true` になる。