### PR TITLE
feat(terraform): manage GitHub repositories

### DIFF
--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -9,12 +9,13 @@ Terraform は次の resource を管理する。
 
 | Resource | 用途 |
 |----------|------|
-| `github_repository.repositories` | repository settings |
-| `github_branch_default.repositories` | default branch |
-| `github_actions_secret.repository` | GitHub Actions repository secrets |
-| `data.external.onepassword_actions_secret` | 1Password から secret value を読む external data source |
+| `github_repository.repositories` | active repository settings |
+| `github_repository.archived` | archive 済み repository の archived state |
+| `github_branch_default.repositories` | active repository の default branch |
+| `github_actions_secret.repository` | active repository の GitHub Actions repository secrets |
+| `data.external.onepassword_actions_secrets` | 1Password から secret value をまとめて読む external data source |
 
-`github_repository.repositories` は `prevent_destroy = true` を使う。
+`github_repository.repositories` と `github_repository.archived` は `prevent_destroy = true` を使う。
 Terraform から repository を破棄しない。
 
 ## Provider と Backend
@@ -22,7 +23,7 @@ Terraform から repository を破棄しない。
 | 対象 | 値 |
 |------|----|
 | Terraform | `>= 1.5.0` |
-| GitHub provider | `integrations/github` `6.12.1` |
+| GitHub provider | `integrations/github` `6.13.0` |
 | External provider | `hashicorp/external` `2.4.0` |
 | GitHub owner | `Soli0222` |
 | State backend | Cloudflare R2 S3 compatible backend |
@@ -49,6 +50,7 @@ terraform plan
 | `repositories.tf` | `github_repository` と `github_branch_default` |
 | `actions_secrets.tf` | 1Password backed `github_actions_secret` |
 | `op-read-secret.rb` | external provider から呼ぶ 1Password 読み取り helper |
+| `import-existing-repositories.sh` | 既存 repository と default branch の再開可能な import helper |
 | `setup.sh` | `GITHUB_TOKEN` と R2 backend credentials の export |
 
 ## Repository Settings
@@ -60,31 +62,65 @@ terraform plan
 現行の global default は repository を public にし、pull request merge 後の branch 削除を有効にする。
 secret scanning と push protection は global で有効にする。
 `mk-stream` と `spotify-nowplaying` は個別 override で secret scanning を無効にする。
+Private repository では `security_and_analysis` blockを生成しない。
+今回追加した既存repositoryは `topics: []` でoverrideし、globalの `renovate` topicを追加しない。
+
+archive 済み repository は `github_repository.archived` で `archived` state だけを管理する。
+GitHub がarchive後のrepository settingsをread-onlyにするため、それ以外の属性は `ignore_changes` とする。
+default branch と Actions secrets も `active_repositories` だけを対象とし、archive 済み repository への更新は行わない。
 
 `has_downloads`、`vulnerability_alerts`、`ignore_vulnerability_alerts_during_read` は provider 側で deprecated または no-op 扱いである。
 YAML の管理対象から外し、Terraform 側の `ignore_changes` で plan noise を抑える。
 
 ## Managed Repositories
 
-現行の `repositories.yaml` は次の repository を管理する。
+現行の `repositories.yaml` は次の active repository を管理する。
 
 ```text
+amemado
 daypassed-bot
 diary-cli
 emoji-bot-gateway
 emoji-renderer
-helm-charts
+exiforge
+homebrew-exiforge
+keymap
+kubecon-schedule
+Mac-NowPlaying
 mk-stream
 note-tweet-connector
 pgroonga-cnpg
+picpress
 pke
+polestar-hub
+polestar_wrapped
 rss-fetcher
+shared-workflows
+soli-site
+spn-cli
 spotify-nowplaying
 spotify-reblend
 sui
 summaly
 vip-responder
+VVCSoftware_VTM
 webhook-test
+```
+
+次の archive 済み repository は archived state だけを管理する。
+
+```text
+antenna_del_spam
+audioroute
+Charmy
+cloudflare-ingress-controller
+debug-image
+flow-sight
+helm-charts
+misskey-summarizer
+mk-anniv
+subscription-manager
+summaly-server
 ```
 
 ## GitHub Actions Secrets
@@ -95,6 +131,9 @@ repository 個別の secret は `repositories.<name>.actions_secrets` に置く�
 同名 secret がある場合は repository 個別の指定が優先される。
 
 現行の global secret は Renovate 用 GitHub App credential である。
+
+同じ 1Password source はリポジトリ数にかかわらず1回だけ読み取る。
+すべての一意な source を単一の external data source へ渡し、helper 内で順次取得するため、1Password Desktop の delegated session を並列に確立しない。
 
 | Secret | 1Password source |
 |--------|------------------|
@@ -158,10 +197,20 @@ terraform plan
 
 新しい repository を追加する。
 
-1. `repositories.yaml` の `repositories` に repository 名を追加する。
-2. GitHub 側に既存 repository がある場合は `terraform import 'github_repository.repositories["<repo>"]' <repo>` を実行する。
-3. default branch も `terraform import 'github_branch_default.repositories["<repo>"]' <repo>` で import する。
+1. `repositories.yaml` の `repositories` に repository 名を追加する。archive 済みの場合は `archived: true` と現在値に必要な override も指定する。
+2. GitHub 側に既存 repository がある場合、activeなら `terraform import 'github_repository.repositories["<repo>"]' <repo>`、archive済みなら `terraform import 'github_repository.archived["<repo>"]' <repo>` を実行する。
+3. active repository の場合だけ、default branch も `terraform import 'github_branch_default.repositories["<repo>"]' <repo>` で import する。
 4. `terraform plan` で差分を確認する。
+
+複数の既存 repository をまとめて import または中断後に再開する場合は helper を使う。
+state に存在する resource は自動的に skipし、archive 済み repository の default branch は対象外にする。
+
+```bash
+cd terraform/github
+source ./setup.sh
+./import-existing-repositories.sh --check
+./import-existing-repositories.sh
+```
 
 既存 secret を Terraform 管理へ追加する。
 

--- a/terraform/github/actions_secrets.tf
+++ b/terraform/github/actions_secrets.tf
@@ -1,18 +1,9 @@
-data "external" "onepassword_actions_secret" {
-  for_each = local.repository_actions_secret_specs
-
+data "external" "onepassword_actions_secrets" {
   program = ["${path.module}/op-read-secret.rb"]
 
-  query = merge(
-    {
-      repository  = each.value.onepassword.repository
-      secret_name = each.value.onepassword.secret_name
-    },
-    {
-      for key, value in try(each.value.onepassword, {}) : key => tostring(value)
-      if value != null
-    },
-  )
+  query = {
+    sources = jsonencode(local.onepassword_actions_secret_sources)
+  }
 }
 
 resource "github_actions_secret" "repository" {
@@ -20,5 +11,7 @@ resource "github_actions_secret" "repository" {
 
   repository  = split("/", each.key)[0]
   secret_name = split("/", each.key)[1]
-  value       = sensitive(data.external.onepassword_actions_secret[each.key].result.value)
+  value = sensitive(data.external.onepassword_actions_secrets.result[
+    local.repository_actions_secret_specs[each.key].onepassword_source_key
+  ])
 }

--- a/terraform/github/import-existing-repositories.sh
+++ b/terraform/github/import-existing-repositories.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+check_only=false
+
+case "${1:-}" in
+  "") ;;
+  --check) check_only=true ;;
+  *)
+    echo "usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac
+
+state_addresses="$(terraform state list)"
+missing_count=0
+
+state_has() {
+  grep -Fqx -- "$1" <<<"${state_addresses}"
+}
+
+remember_state() {
+  state_addresses="${state_addresses}"$'\n'"$1"
+}
+
+while IFS=$'\t' read -r repository archived; do
+  if [[ "${archived}" == "true" ]]; then
+    repository_address="github_repository.archived[\"${repository}\"]"
+  else
+    repository_address="github_repository.repositories[\"${repository}\"]"
+  fi
+
+  if state_has "${repository_address}"; then
+    echo "repository already imported: ${repository}"
+  elif [[ "${check_only}" == "true" ]]; then
+    echo "repository missing: ${repository}"
+    missing_count=$((missing_count + 1))
+  else
+    terraform import -parallelism=1 "${repository_address}" "${repository}"
+    remember_state "${repository_address}"
+    echo "repository imported: ${repository}"
+  fi
+
+  if [[ "${archived}" == "true" ]]; then
+    continue
+  fi
+
+  branch_address="github_branch_default.repositories[\"${repository}\"]"
+
+  if state_has "${branch_address}"; then
+    echo "default branch already imported: ${repository}"
+  elif [[ "${check_only}" == "true" ]]; then
+    echo "default branch missing: ${repository}"
+    missing_count=$((missing_count + 1))
+  else
+    terraform import -parallelism=1 "${branch_address}" "${repository}"
+    remember_state "${branch_address}"
+    echo "default branch imported: ${repository}"
+  fi
+done < <(
+  ruby -ryaml -e '
+    repositories = YAML.load_file("repositories.yaml").fetch("repositories")
+    repositories.sort_by { |name, _| name.downcase }.each do |name, settings|
+      puts [name, settings.fetch("archived", false)].join("\t")
+    end
+  '
+)
+
+if [[ "${check_only}" == "true" ]]; then
+  echo "missing resources: ${missing_count}"
+fi

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -8,34 +8,50 @@ locals {
       local.repository_defaults,
       repository,
       {
-        security_and_analysis = merge(
-          try(local.repository_defaults.security_and_analysis, {}),
-          try(repository.security_and_analysis, {}),
+        security_and_analysis = (
+          try(repository.visibility, local.repository_defaults.visibility) == "private" ? null : merge(
+            try(local.repository_defaults.security_and_analysis, {}),
+            try(repository.security_and_analysis, {}),
+          )
         )
       },
     )
   }
 
+  active_repositories = {
+    for name, repository in local.repositories : name => repository
+    if !repository.archived
+  }
+
+  archived_repositories = {
+    for name, repository in local.repositories : name => repository
+    if repository.archived
+  }
+
   global_actions_secret_specs = try(local.github_config.global.actions_secrets, {})
 
   repository_actions_secret_specs = merge(flatten([
-    for repository in keys(local.repositories) : [
+    for repository in keys(local.active_repositories) : [
       {
         for secret_name, secret in merge(
           local.global_actions_secret_specs,
           try(local.github_config.repositories[repository].actions_secrets, {}),
           ) : "${repository}/${secret_name}" => merge(secret, {
-            onepassword = merge(
-              try(secret.onepassword, {}),
-              {
-                repository  = repository
-                secret_name = secret_name
-              },
-            )
+            onepassword_source_key = sha256(jsonencode(try(secret.onepassword, {})))
         })
       }
     ]
   ])...)
+
+  onepassword_actions_secret_source_groups = {
+    for secret in values(local.repository_actions_secret_specs) :
+    secret.onepassword_source_key => secret.onepassword...
+  }
+
+  onepassword_actions_secret_sources = {
+    for source_key, sources in local.onepassword_actions_secret_source_groups :
+    source_key => sources[0]
+  }
 
   repository_actions_secret_keys = toset(keys(local.repository_actions_secret_specs))
 }

--- a/terraform/github/op-read-secret.rb
+++ b/terraform/github/op-read-secret.rb
@@ -5,8 +5,6 @@ require "json"
 require "open3"
 require "shellwords"
 
-query = JSON.parse($stdin.read)
-
 def fail_with(message)
   warn(message)
   exit 1
@@ -38,18 +36,16 @@ def reference_value(reference)
   run_command("op", "read", reference)
 end
 
-reference = query["reference"]
-item = query["item"]
-field = query["field"]
-file = query["file"]
-vault = query["vault"]
-repository = query["repository"]
-secret_name = query["secret_name"]
+def secret_value(source, source_key)
+  unknown_keys = source.keys - %w[reference vault item field file]
+  fail_with("unknown onepassword keys for source #{source_key}: #{unknown_keys.join(", ")}") unless unknown_keys.empty?
 
-unknown_keys = query.keys - %w[repository secret_name reference vault item field file]
-fail_with("unknown onepassword keys for #{repository}/#{secret_name}: #{unknown_keys.join(", ")}") unless unknown_keys.empty?
+  reference = source["reference"]
+  item = source["item"]
+  field = source["field"]
+  file = source["file"]
+  vault = source["vault"]
 
-value =
   if reference && !reference.empty?
     reference_value(reference)
   elsif item && field && !item.empty? && !field.empty?
@@ -57,7 +53,21 @@ value =
   elsif item && file && vault && !item.empty? && !file.empty? && !vault.empty?
     reference_value("op://#{vault}/#{item}/#{file}")
   else
-    fail_with("onepassword source for #{repository}/#{secret_name} requires either reference, item+field, or vault+item+file")
+    fail_with("onepassword source #{source_key} requires either reference, item+field, or vault+item+file")
   end
+end
 
-print JSON.generate({ "value" => value })
+query = JSON.parse($stdin.read)
+unknown_query_keys = query.keys - %w[sources]
+fail_with("unknown query keys: #{unknown_query_keys.join(", ")}") unless unknown_query_keys.empty?
+
+sources = JSON.parse(query.fetch("sources"))
+fail_with("sources must be a JSON object") unless sources.is_a?(Hash)
+
+values = sources.sort.each_with_object({}) do |(source_key, source), result|
+  fail_with("onepassword source #{source_key} must be a JSON object") unless source.is_a?(Hash)
+
+  result[source_key] = secret_value(source, source_key)
+end
+
+print JSON.generate(values)

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -1,5 +1,5 @@
 resource "github_repository" "repositories" {
-  for_each = local.repositories
+  for_each = local.active_repositories
 
   name                        = each.key
   allow_auto_merge            = each.value.allow_auto_merge
@@ -93,8 +93,52 @@ resource "github_repository" "repositories" {
   }
 }
 
+resource "github_repository" "archived" {
+  for_each = local.archived_repositories
+
+  name     = each.key
+  archived = true
+
+  lifecycle {
+    prevent_destroy = true
+
+    # GitHub makes repository settings read-only after archival. Keep the
+    # archived state under management without attempting unsupported updates.
+    ignore_changes = [
+      allow_auto_merge,
+      allow_forking,
+      allow_merge_commit,
+      allow_rebase_merge,
+      allow_squash_merge,
+      allow_update_branch,
+      auto_init,
+      delete_branch_on_merge,
+      description,
+      gitignore_template,
+      has_discussions,
+      has_downloads,
+      has_issues,
+      has_projects,
+      has_wiki,
+      homepage_url,
+      ignore_vulnerability_alerts_during_read,
+      is_template,
+      license_template,
+      merge_commit_message,
+      merge_commit_title,
+      security_and_analysis,
+      squash_merge_commit_message,
+      squash_merge_commit_title,
+      topics,
+      visibility,
+      vulnerability_alerts,
+      web_commit_signoff_required,
+    ]
+  }
+}
+
 resource "github_branch_default" "repositories" {
-  for_each = local.repositories
+  for_each = local.active_repositories
 
   repository = github_repository.repositories[each.key].name
   branch     = each.value.default_branch

--- a/terraform/github/repositories.yaml
+++ b/terraform/github/repositories.yaml
@@ -40,7 +40,51 @@ global:
         file: private-key.pem
 
 repositories:
+  amemado:
+    topics: []
+    visibility: private
+
+  antenna_del_spam:
+    archived: true
+    delete_branch_on_merge: false
+    topics: []
+    security_and_analysis:
+      secret_scanning: disabled
+      secret_scanning_push_protection: disabled
+
+  audioroute:
+    archived: true
+    has_wiki: false
+    topics: []
+    visibility: private
+    security_and_analysis:
+      secret_scanning: disabled
+      secret_scanning_push_protection: disabled
+
+  Charmy:
+    archived: true
+    delete_branch_on_merge: false
+    has_wiki: false
+    topics: []
+    security_and_analysis:
+      secret_scanning: disabled
+      secret_scanning_push_protection: disabled
+
+  cloudflare-ingress-controller:
+    archived: true
+    delete_branch_on_merge: false
+    topics: []
+    security_and_analysis:
+      secret_scanning_push_protection: disabled
+
   daypassed-bot: {}
+
+  debug-image:
+    archived: true
+    delete_branch_on_merge: false
+    topics: []
+    security_and_analysis:
+      secret_scanning_push_protection: disabled
 
   diary-cli: {}
 
@@ -48,11 +92,42 @@ repositories:
 
   emoji-renderer: {}
 
+  exiforge:
+    topics: []
+
+  flow-sight:
+    archived: true
+    delete_branch_on_merge: false
+    topics: []
+    security_and_analysis:
+      secret_scanning_push_protection: disabled
+
   helm-charts:
     archived: true
     description: >-
       Retired. Charts moved to the application repositories
       (oci://ghcr.io/soli0222/charts) and to pke/charts/.
+    security_and_analysis:
+      secret_scanning_push_protection: disabled
+
+  homebrew-exiforge:
+    topics: []
+
+  keymap:
+    topics: []
+
+  kubecon-schedule:
+    topics: []
+    visibility: private
+
+  Mac-NowPlaying:
+    topics: []
+
+  misskey-summarizer:
+    archived: true
+    topics: []
+    security_and_analysis:
+      secret_scanning_push_protection: disabled
 
   mk-stream:
     security_and_analysis:
@@ -70,6 +145,14 @@ repositories:
           item: Github Docker
           field: DOCKER_HUB_USERNAME
 
+  mk-anniv:
+    archived: true
+    delete_branch_on_merge: false
+    topics: []
+    security_and_analysis:
+      secret_scanning: disabled
+      secret_scanning_push_protection: disabled
+
   note-tweet-connector:
     actions_secrets:
       DOCKER_HUB_ACCESS_TOKEN:
@@ -85,8 +168,18 @@ repositories:
 
   pgroonga-cnpg: {}
 
+  picpress:
+    topics: []
+
   pke:
     description: Polestar Kubernetes Engine
+
+  polestar-hub:
+    topics: []
+
+  polestar_wrapped:
+    topics: []
+    visibility: private
 
   rss-fetcher: {}
 
@@ -113,6 +206,13 @@ repositories:
 
   spotify-reblend: {}
 
+  soli-site:
+    has_discussions: true
+    topics: []
+
+  spn-cli:
+    topics: []
+
   sui: {}
 
   summaly:
@@ -120,7 +220,28 @@ repositories:
     description: "\U0001F50D Get a summary of any web page"
     has_wiki: false
 
+  summaly-server:
+    archived: true
+    delete_branch_on_merge: false
+    homepage_url: https://summaly-server.vercel.app
+    topics: []
+    security_and_analysis:
+      secret_scanning: disabled
+      secret_scanning_push_protection: disabled
+
+  subscription-manager:
+    archived: true
+    delete_branch_on_merge: false
+    topics: []
+    security_and_analysis:
+      secret_scanning_push_protection: disabled
+
   vip-responder: {}
+
+  VVCSoftware_VTM:
+    default_branch: master
+    topics: []
+    visibility: private
 
   webhook-test:
     actions_secrets:


### PR DESCRIPTION
## 概要

Soli0222 所有のGitHubリポジトリを `terraform/github` の管理対象へ追加します。

- active repositoryの設定、default branch、Actions secretsをTerraform管理
- archive済みrepositoryはarchived stateのみ管理
- Private repositoryではsecurity analysis設定を生成しない
- 1Password secret sourceを重複排除し、単一helper内で逐次取得
- 中断後に再開可能なrepository import helperを追加

## 背景

既存リポジトリの管理範囲を整理し、active/archiveを分離したうえでGitHub設定を一元管理するためです。
1Password CLIをリポジトリ数分並列起動してdelegated sessionが失敗する問題も解消します。

## 確認

- `terraform apply`: 24 added, 12 changed, 0 destroyed
- `terraform validate`
- `terraform fmt -check`
- Ruby構文確認
- Bash構文確認
- `git diff --check`
